### PR TITLE
Added OS-independent uninstaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,21 @@ FROM python:latest
 WORKDIR /app
 
 # set environment variables
-RUN apt-get update
+RUN apt-get -y update
 RUN apt-get -y install dnsutils
+# dependencies for psycopg2
+RUN apt-get -y install libpq-dev 
+RUN apt-get -y install python3-dev
+
+# Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
 # copy project
 COPY . /app/
+
+# Install requirements
+RUN pip install -r /app/requirements.txt
 
 # install pygoat
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ RUN apt-get -y install python3-dev
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
+# Install dependencies
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
 # copy project
 COPY . /app/
-
-# Install requirements
-RUN pip install -r /app/requirements.txt
 
 # install pygoat
 EXPOSE 8000

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import os
+import sys
+import ctypes
+import platform
+import colorama
+import subprocess
+from shutil import rmtree
+
+
+# Platform indepent way to check if user is admin
+def is_user_admin():
+    """
+    Check if the script is being run as root/admin
+
+    Return False if privileges cannot be determined
+    """
+    if platform.system()=='Windows':
+        try:
+            return ctypes.windll.shell32.IsUserAnAdmin() == 1
+        except:
+            return False
+    
+    else:
+        try:
+            return os.getuid()==0
+        except:
+            return False
+
+
+# Uninstall Pip packages in a platform independent way
+def uninstall_pip_packages():
+    """Remove pip packages installed by pygoat""" 
+    print(colorama.Back.CYAN+colorama.Style.BRIGHT+"[+] Uninstalling Pip packages!"+colorama.Style.RESET_ALL)
+    try:
+        subprocess.check_call([sys.executable,"-m", "pip", "uninstall","-yr","requirements.txt"])
+    except:
+        print(colorama.Fore.RED+colorama.Style.BRIGHT+"[!] Failed to uninstall pip packages")
+        print(colorama.Style.RESET_ALL)
+
+
+# Uninstall PIP
+def uninstall_pip():
+    """Remove Pip"""
+    print(colorama.Back.RED+colorama.Style.BRIGHT+"[+] Uninstalling Pip!"+colorama.Style.RESET_ALL)
+    try:
+        subprocess.check_call([sys.executable,"-m", "pip", "uninstall","-y","pip"])
+    except:
+        print(colorama.Fore.RED+colorama.Style.BRIGHT+"[!] Failed to uninstall pip")
+        print(colorama.Style.RESET_ALL)
+
+
+# Remove pygoat
+def remove_pygoat():
+    """Remove pygoat files"""
+    cwd = os.getcwd()
+    print(colorama.Back.RED+colorama.Style.BRIGHT+f"All files in {cwd} will be deleted!"+colorama.Style.RESET_ALL)
+    for item in os.listdir(cwd):
+        if platform.system()=='Windows':
+            filename = cwd + '\\' + item
+        else:
+            filename = cwd + '/' + item
+
+        if(os.path.isfile(filename)):
+            try:
+                print("[!] Deleted: "+colorama.Fore.RED+colorama.Style.BRIGHT+filename+colorama.Style.RESET_ALL)
+                os.remove(filename)
+            except:
+                print(colorama.Fore.RED+colorama.Style.BRIGHT+f"[!] Failed To remove: {filename}"+colorama.Style.RESET_ALL)
+                pass
+
+        if(os.path.isdir(filename)):
+            try:
+                print("[!] Deleted: "+colorama.Fore.RED+colorama.Style.BRIGHT+filename+colorama.Style.RESET_ALL)
+                rmtree(filename)
+            except:
+                print(colorama.Fore.RED+colorama.Style.BRIGHT+f"[!] Failed To remove: {filename}"+colorama.Style.RESET_ALL)
+                pass
+
+def main():
+    colorama.init()
+
+    # Check if program is being run as admin
+    # However, you need admin privileges only if you are not in a venv
+    if(not is_user_admin() and sys.prefix == sys.base_prefix):
+        print(colorama.Fore.RED+colorama.Style.BRIGHT+"[!] This script must be run as root!")
+        print(colorama.Style.RESET_ALL)
+        sys.exit(-1)
+
+    # Remove pip packages
+    uninstall_pip_packages()
+
+    # Remove pip
+    choice = input("Uninstall pip? (y/N) ")
+    if (choice.upper()=='Y' or choice.upper()=='YES'):
+        uninstall_pip()
+    
+    else:
+        print(colorama.Back.CYAN+colorama.Style.BRIGHT+"[+] Pip has been kept intact"+colorama.Style.RESET_ALL)
+
+    # Remove pygoat files
+    choice = input("Would you like to remove all pygoat directories and files? (y/N) ")
+    if (choice.upper()=='Y'or choice.upper()=='YES'):
+        remove_pygoat()
+        choice2 = input(f"Remove {os.getcwd()}? (y/N) ")
+        if (choice2.upper()=='Y'or choice2.upper()=='YES'):
+            try:
+                rmtree(os.getcwd())
+                print(colorama.Back.RED+colorama.Style.BRIGHT+f"[+] {os.getcwd()} has been removed"+colorama.Style.RESET_ALL)
+            except PermissionError:
+                print(colorama.Back.RED+colorama.Style.BRIGHT+f"[+] Could Not remove {os.getcwd()} due to insufficient permissions"+colorama.Style.RESET_ALL)
+                pass
+            except:
+                pass
+    
+    else:
+        print(colorama.Back.CYAN+colorama.Style.BRIGHT+f"[+] {os.getcwd()} has been kept intact"+colorama.Style.RESET_ALL)
+
+    # Restore output streams to their original values
+    colorama.deinit()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
### Added `uninstaller.py`

The current `uninstaller.sh` script is specific to Debian/Ubuntu based distributions. This PR adds `uninstaller.py`: an OS-Independent script which uninstalls `pygoat` from your distribution regardless of the underlying Operating System.

### Tested On:
The script has been tested on the following platforms:
- Windows 10
- Arch Linux
- Debian Bullseye