### PR TITLE
Fix multiple issues with uninstallation and venv installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ django-heroku
 whitenoise
 django-allauth
 Django==4.0.4
+colorama

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 wheel
 asgiref
-Django
 pytz==2020.1
 sqlparse==0.3.1
 php-wsgi
@@ -10,3 +9,4 @@ gunicorn
 django-heroku
 whitenoise
 django-allauth
+Django==4.0.4

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -5,7 +5,7 @@ import ctypes
 import platform
 import colorama
 import subprocess
-from shutil import rmtree
+from shutil import rmtree, which
 
 
 # Platform indepent way to check if user is admin
@@ -37,6 +37,15 @@ def uninstall_pip_packages():
           colorama.Style.RESET_ALL)
 
     try:
+        # It is important to upgrade pip first to avoid environment errors
+        if (platform.system != 'Windows'):
+            pip_v = "pip3" if (which('pip3') != None) else "pip"
+            subprocess.run([pip_v,
+                            "install",
+                            "--upgrade",
+                            "pip"],
+                           stdout = subprocess.DEVNULL,
+                           stderr = subprocess.DEVNULL)
         subprocess.check_call([sys.executable,
                                "-m",
                                "pip",

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -144,19 +144,19 @@ def main():
         remove_pygoat()
         choice2 = input(f"Remove {os.getcwd()}? (y/N) ")
         if (choice2.upper() == 'Y' or choice2.upper() == 'YES'):
-            rmtree(os.getcwd(), ignore_errors=True)
-            print(colorama.Back.RED +
-                  colorama.Style.BRIGHT +
-                  f"[+] {os.getcwd()} has been removed" +
-                  colorama.Style.RESET_ALL)
+            try:
+                rmtree(os.getcwd(), ignore_errors=True)
+                print(colorama.Back.RED +
+                      colorama.Style.BRIGHT +
+                      f"[+] {os.getcwd()} has been removed" +
+                      colorama.Style.RESET_ALL)
+            except FileNotFoundError:
+                pass
     else:
-        try:
-            print(colorama.Back.CYAN +
-                  colorama.Style.BRIGHT +
-                  f"[+] {os.getcwd()} has been kept intact" +
-                  colorama.Style.RESET_ALL)
-        except FileNotFoundError:
-            pass
+        print(colorama.Back.CYAN +
+              colorama.Style.BRIGHT +
+              f"[+] {os.getcwd()} has been kept intact" +
+              colorama.Style.RESET_ALL)
 
     # Restore output streams to their original values
     colorama.deinit()

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -150,10 +150,13 @@ def main():
                   f"[+] {os.getcwd()} has been removed" +
                   colorama.Style.RESET_ALL)
     else:
-        print(colorama.Back.CYAN +
-              colorama.Style.BRIGHT +
-              f"[+] {os.getcwd()} has been kept intact" +
-              colorama.Style.RESET_ALL)
+        try:
+            print(colorama.Back.CYAN +
+                  colorama.Style.BRIGHT +
+                  f"[+] {os.getcwd()} has been kept intact" +
+                  colorama.Style.RESET_ALL)
+        except FileNotFoundError:
+            pass
 
     # Restore output streams to their original values
     colorama.deinit()

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -15,67 +15,100 @@ def is_user_admin():
 
     Return False if privileges cannot be determined
     """
-    if platform.system()=='Windows':
+    if platform.system() == 'Windows':
         try:
             return ctypes.windll.shell32.IsUserAnAdmin() == 1
-        except:
+        except WindowsError:
             return False
-    
+
     else:
         try:
-            return os.getuid()==0
-        except:
+            return os.getuid() == 0
+        except os.Error:
             return False
 
 
 # Uninstall Pip packages in a platform independent way
 def uninstall_pip_packages():
-    """Remove pip packages installed by pygoat""" 
-    print(colorama.Back.CYAN+colorama.Style.BRIGHT+"[+] Uninstalling Pip packages!"+colorama.Style.RESET_ALL)
+    """Remove pip packages installed by pygoat"""
+    print(colorama.Back.CYAN +
+          colorama.Style.BRIGHT +
+          "[+] Uninstalling Pip packages!" +
+          colorama.Style.RESET_ALL)
+
     try:
-        subprocess.check_call([sys.executable,"-m", "pip", "uninstall","-yr","requirements.txt"])
-    except:
-        print(colorama.Fore.RED+colorama.Style.BRIGHT+"[!] Failed to uninstall pip packages")
-        print(colorama.Style.RESET_ALL)
+        subprocess.check_call([sys.executable,
+                               "-m",
+                               "pip",
+                               "uninstall",
+                               "-yr",
+                               "requirements.txt"])
+    except subprocess.CalledProcessError:
+        print(colorama.Fore.RED +
+              colorama.Style.BRIGHT +
+              "[!] Failed to uninstall pip packages" +
+              colorama.Style.RESET_ALL)
 
 
 # Uninstall PIP
 def uninstall_pip():
     """Remove Pip"""
-    print(colorama.Back.RED+colorama.Style.BRIGHT+"[+] Uninstalling Pip!"+colorama.Style.RESET_ALL)
+    print(colorama.Back.RED +
+          colorama.Style.BRIGHT +
+          "[+] Uninstalling Pip!" +
+          colorama.Style.RESET_ALL)
     try:
-        subprocess.check_call([sys.executable,"-m", "pip", "uninstall","-y","pip"])
-    except:
-        print(colorama.Fore.RED+colorama.Style.BRIGHT+"[!] Failed to uninstall pip")
-        print(colorama.Style.RESET_ALL)
+        subprocess.check_call([sys.executable,
+                               "-m",
+                               "pip",
+                               "uninstall",
+                               "-y",
+                               "pip"])
+    except subprocess.CalledProcessError:
+        print(colorama.Fore.RED +
+              colorama.Style.BRIGHT +
+              "[!] Failed to uninstall pip" +
+              colorama.Style.RESET_ALL)
 
 
 # Remove pygoat
 def remove_pygoat():
     """Remove pygoat files"""
     cwd = os.getcwd()
-    print(colorama.Back.RED+colorama.Style.BRIGHT+f"All files in {cwd} will be deleted!"+colorama.Style.RESET_ALL)
+    print(colorama.Back.RED +
+          colorama.Style.BRIGHT +
+          f"All files in {cwd} will be deleted!" +
+          colorama.Style.RESET_ALL)
+
     for item in os.listdir(cwd):
-        if platform.system()=='Windows':
+        if platform.system() == 'Windows':
             filename = cwd + '\\' + item
         else:
             filename = cwd + '/' + item
 
         if(os.path.isfile(filename)):
             try:
-                print("[!] Deleted: "+colorama.Fore.RED+colorama.Style.BRIGHT+filename+colorama.Style.RESET_ALL)
+                print("[!] Deleted: " +
+                      colorama.Fore.RED +
+                      colorama.Style.BRIGHT +
+                      filename +
+                      colorama.Style.RESET_ALL)
                 os.remove(filename)
-            except:
-                print(colorama.Fore.RED+colorama.Style.BRIGHT+f"[!] Failed To remove: {filename}"+colorama.Style.RESET_ALL)
+            except os.Error:
+                print(colorama.Fore.RED +
+                      colorama.Style.BRIGHT +
+                      f"[!] Failed To remove: {filename}" +
+                      colorama.Style.RESET_ALL)
                 pass
 
         if(os.path.isdir(filename)):
-            try:
-                print("[!] Deleted: "+colorama.Fore.RED+colorama.Style.BRIGHT+filename+colorama.Style.RESET_ALL)
-                rmtree(filename)
-            except:
-                print(colorama.Fore.RED+colorama.Style.BRIGHT+f"[!] Failed To remove: {filename}"+colorama.Style.RESET_ALL)
-                pass
+            print("[!] Deleted: " +
+                  colorama.Fore.RED +
+                  colorama.Style.BRIGHT +
+                  filename +
+                  colorama.Style.RESET_ALL)
+            rmtree(filename, ignore_errors=True)
+
 
 def main():
     colorama.init()
@@ -83,8 +116,10 @@ def main():
     # Check if program is being run as admin
     # However, you need admin privileges only if you are not in a venv
     if(not is_user_admin() and sys.prefix == sys.base_prefix):
-        print(colorama.Fore.RED+colorama.Style.BRIGHT+"[!] This script must be run as root!")
-        print(colorama.Style.RESET_ALL)
+        print(colorama.Fore.RED +
+              colorama.Style.BRIGHT +
+              "[!] This script must be run as root!" +
+              colorama.Style.RESET_ALL)
         sys.exit(-1)
 
     # Remove pip packages
@@ -92,32 +127,37 @@ def main():
 
     # Remove pip
     choice = input("Uninstall pip? (y/N) ")
-    if (choice.upper()=='Y' or choice.upper()=='YES'):
+    if (choice.upper() == 'Y' or choice.upper() == 'YES'):
         uninstall_pip()
-    
     else:
-        print(colorama.Back.CYAN+colorama.Style.BRIGHT+"[+] Pip has been kept intact"+colorama.Style.RESET_ALL)
+        print(colorama.Back.CYAN +
+              colorama.Style.BRIGHT +
+              "[+] Pip has been kept intact" +
+              colorama.Style.RESET_ALL)
 
     # Remove pygoat files
-    choice = input("Would you like to remove all pygoat directories and files? (y/N) ")
-    if (choice.upper()=='Y'or choice.upper()=='YES'):
+    choice = input(
+        "Would you like to remove all pygoat directories and files? (y/N) "
+    )
+
+    if (choice.upper() == 'Y' or choice.upper() == 'YES'):
         remove_pygoat()
         choice2 = input(f"Remove {os.getcwd()}? (y/N) ")
-        if (choice2.upper()=='Y'or choice2.upper()=='YES'):
-            try:
-                rmtree(os.getcwd())
-                print(colorama.Back.RED+colorama.Style.BRIGHT+f"[+] {os.getcwd()} has been removed"+colorama.Style.RESET_ALL)
-            except PermissionError:
-                print(colorama.Back.RED+colorama.Style.BRIGHT+f"[+] Could Not remove {os.getcwd()} due to insufficient permissions"+colorama.Style.RESET_ALL)
-                pass
-            except:
-                pass
-    
+        if (choice2.upper() == 'Y' or choice2.upper() == 'YES'):
+            rmtree(os.getcwd(), ignore_errors=True)
+            print(colorama.Back.RED +
+                  colorama.Style.BRIGHT +
+                  f"[+] {os.getcwd()} has been removed" +
+                  colorama.Style.RESET_ALL)
     else:
-        print(colorama.Back.CYAN+colorama.Style.BRIGHT+f"[+] {os.getcwd()} has been kept intact"+colorama.Style.RESET_ALL)
+        print(colorama.Back.CYAN +
+              colorama.Style.BRIGHT +
+              f"[+] {os.getcwd()} has been kept intact" +
+              colorama.Style.RESET_ALL)
 
     # Restore output streams to their original values
     colorama.deinit()
+
 
 if __name__ == '__main__':
     main()

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -39,13 +39,13 @@ def uninstall_pip_packages():
     try:
         # It is important to upgrade pip first to avoid environment errors
         if (platform.system != 'Windows'):
-            pip_v = "pip3" if (which('pip3') != None) else "pip"
+            pip_v = "pip3" if (which('pip3') is not None) else "pip"
             subprocess.run([pip_v,
                             "install",
                             "--upgrade",
                             "pip"],
-                           stdout = subprocess.DEVNULL,
-                           stderr = subprocess.DEVNULL)
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL)
         subprocess.check_call([sys.executable,
                                "-m",
                                "pip",
@@ -166,6 +166,11 @@ def main():
               colorama.Style.BRIGHT +
               f"[+] {os.getcwd()} has been kept intact" +
               colorama.Style.RESET_ALL)
+
+    print(colorama.Back.RED +
+          colorama.Style.BRIGHT +
+          "Uninstallations Done!" +
+          colorama.Style.RESET_ALL)
 
     # Restore output streams to their original values
     colorama.deinit()


### PR DESCRIPTION
# Changes Described
## Fixing `requirements.txt`
When installing `pygoat` in a venv using `setup.py` script, the following error occurs:
```
error: The 'Django' distribution was not found and is required by django-heroku, pygoat
```
This PR fixes the said error by proper ordering of packages and added missing module `colorama`

## Fixing `uninstaller.py`
This PR fixes the environment issue while uninstalling `pip`. If `pip` is installed via a package manager, we get the following error:
```
Found existing installation: pip 20.3.4
Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
Can't uninstall 'pip'. No files were found to uninstall.
```
This PR fixes this as well used `flake8` to follow PEP8 conventions. 