### PR TITLE
Fix cryptographic lab by populating CF_user table

### DIFF
--- a/introduction/migrations/0017_cf_user.py
+++ b/introduction/migrations/0017_cf_user.py
@@ -18,4 +18,10 @@ class Migration(migrations.Migration):
                 ('password', models.CharField(max_length=200)),
             ],
         ),
+        migrations.RunSQL(
+            "INSERT INTO introduction_cf_user (username, password) VALUES "
+            "('alex', '9d6edee6ce9312981084bd98eb3751ee'),"
+            "('admin', 'c93ccd78b2076528346216b3b2f701e6'),"
+            "('rupak', '5ee3547adb4481902349bdd0f2ffba93');"
+        ),
     ]

--- a/introduction/migrations/0018_cf_user_password2.py
+++ b/introduction/migrations/0018_cf_user_password2.py
@@ -16,4 +16,10 @@ class Migration(migrations.Migration):
             field=models.CharField(default='ok', max_length=64),
             preserve_default=False,
         ),
+        migrations.RunSQL(
+            "INSERT INTO introduction_cf_user (username, password, password2) VALUES "
+            "('alex', '9d6edee6ce9312981084bd98eb3751ee', '2a280ba4ff0f8c763c5b0606f40effc3319dbc4c91d4361a39990292d4b7b0cd'),"
+            "('admin', 'c93ccd78b2076528346216b3b2f701e6', 'd953b4a47ce307fcb8b1b85fc6a0d34aea5585b6ad9188beb94c1eea9bbb5c7a'),"
+            "('rupak', '5ee3547adb4481902349bdd0f2ffba93', 'c17cde8d179a37cad4bd93e55355fdf240eb52d585e428c1cdfecc68123e192a');"
+        ),
     ]


### PR DESCRIPTION
Fixes #221

Insert necessary user data into the `introduction_cf_user` table for the cryptographic failure labs.

* **introduction/migrations/0017_cf_user.py**
  - Insert user data with fields `username` and `password` into the `CF_user` table.
  - Add SQL command to insert user data: 'alex', 'admin', and 'rupak' with their respective passwords.

* **introduction/migrations/0018_cf_user_password2.py**
  - Insert user data with fields `username`, `password`, and `password2` into the `CF_user` table.
  - Add SQL command to insert user data: 'alex', 'admin', and 'rupak' with their respective passwords and password2 values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/adeyosemanputra/pygoat/issues/221?shareId=d2923ffe-90ba-4adb-9300-c017a5c3cfb3).