### PR TITLE
Fix: Invalid crispy-bootstrap4 version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==3.0.1
 cryptography==39.0.1
-crispy-bootstrap4===2024.10
+crispy-bootstrap4==2022.1
 defusedxml==0.7.1
 dj-database-url==0.5.0
 Django==4.2


### PR DESCRIPTION
This PR corrects an invalid dependency version in `requirements.txt`.

- Replaced: `crispy-bootstrap4===2024.10`
- With: `crispy-bootstrap4==2022.1`

### Why?
- `2024.10` is not a valid version on PyPI, and causes installation failure.
- `2022.1` is the latest valid version as of now.
- Also switched from `===` to `==`, which is the recommended operator for PyPI version matching.

### Tested
Tested in a fresh virtual environment and confirmed that `crispy-bootstrap4==2022.1` installs successfully.

No other changes made.
@adeyosemanputra 