### PR TITLE
Optimize Dockerfile of labs for smaller image size

### DIFF
--- a/dockerized_labs/auth_failure_lab/Dockerfile
+++ b/dockerized_labs/auth_failure_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/broken_access_lab/Dockerfile
+++ b/dockerized_labs/broken_access_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/broken_auth_lab/Dockerfile
+++ b/dockerized_labs/broken_auth_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/crypto_failure_lab/Dockerfile
+++ b/dockerized_labs/crypto_failure_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 COPY . .

--- a/dockerized_labs/insec_des_lab/Dockerfile
+++ b/dockerized_labs/insec_des_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/insecure_design_lab/Dockerfile
+++ b/dockerized_labs/insecure_design_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/insufficient_logging_lab/Dockerfile
+++ b/dockerized_labs/insufficient_logging_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/sec_misconfig/Dockerfile
+++ b/dockerized_labs/sec_misconfig/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/sensitive_data_exposure/Dockerfile
+++ b/dockerized_labs/sensitive_data_exposure/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/software_integrity_lab/Dockerfile
+++ b/dockerized_labs/software_integrity_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/sql_injection_lab/Dockerfile
+++ b/dockerized_labs/sql_injection_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/ssrf_lab/Dockerfile
+++ b/dockerized_labs/ssrf_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/template_injection_lab/Dockerfile
+++ b/dockerized_labs/template_injection_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/xss_lab/Dockerfile
+++ b/dockerized_labs/xss_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/dockerized_labs/xxe_lab/Dockerfile
+++ b/dockerized_labs/xxe_lab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR optimizes the lab’s Docker image by switching the base image from python:3.9-slim to python:3.9-alpine, resulting in a significantly smaller image footprint.

**Base Image Migration**

Before: python:3.9-slim (~150-200MB base)
After: python:3.9-alpine (~90-130MB base)