### PR TITLE
fix: Docker build by updating base image and removing EOL dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11.0b1-buster
+FROM python:3.11-slim-bookworm
+
 
 
 # set work directory
@@ -6,7 +7,7 @@ WORKDIR /app
 
 
 # dependencies for psycopg2
-RUN apt-get update && apt-get install --no-install-recommends -y dnsutils=1:9.11.5.P4+dfsg-5.1+deb10u11 libpq-dev=11.16-0+deb10u1 python3-dev=3.7.3-1 && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y dnsutils libpq-dev python3-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 # Set environment variables


### PR DESCRIPTION
##problem:
on the new systems, the PyGoat Docker image build fails because of the operating system base image (`debian:buster`), which is no longer receiving updates from the debian archive (end-of-life). This creates issues with apt repositories returning 404 errors.

##Change Summary
The python base image has been updated to python:3.11-slim-bookworm. All version-pinned debian packages that were using the EOL debian OS image have been removed. no changes to the business logic

