### PR TITLE
docs: add macOS Apple Silicon Docker workaround for Debian buster EOL build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,56 @@ First, Clone the repository using GitHub website or git in Terminal
 4. Browse to <http://127.0.0.1:8000> 
 5. Remove existing image using `docker image rm pygoat/pygoat` and pull again incase of any error
 
+### macOS Apple Silicon (M1 / M2 / M3) Notes
+
+On macOS Apple Silicon (M1 / M2 / M3), building PyGoat locally using
+`docker-compose up --build` or `docker build` may fail due to the base
+Docker image relying on Debian **buster**, which has reached end-of-life (EOL).
+
+This causes `apt-get update` to return `404 Not Found` errors during the
+image build process.
+
+#### Observed Issue
+
+* `apt-get update` fails with `404 Not Found`
+* Error occurs while building from the local `Dockerfile`
+* Caused by deprecated Debian **buster** repositories
+* Reproduced on macOS Apple Silicon (M2, latest macOS)
+
+#### Recommended Workaround (Verified on macOS M2)
+
+Use the prebuilt official Docker image and explicitly specify the platform.
+
+```bash
+docker run --rm \
+  --platform=linux/amd64 \
+  -p 8000:8000 \
+  pygoat/pygoat:latest
+```
+
+Alternatively, using Docker Compose:
+
+Create or edit the `docker-compose.yml` file in the project root directory and use the following configuration:
+
+```yaml
+services:
+  pygoat:
+    image: pygoat/pygoat:latest
+    platform: linux/amd64
+    ports:
+      - "8000:8000"
+```
+
+Then
+
+```bash
+docker compose up
+```
+
+This approach allows PyGoat to run successfully on macOS Apple Silicon
+without modifying the existing `Dockerfile`.
+
+
 ### From Docker-Compose 
 1. Install [Docker](https://www.docker.com)
 2. Run `docker-compose up` or `docker-compose up -d`


### PR DESCRIPTION
### Summary

This PR adds a documentation note for running PyGoat on macOS Apple Silicon
(M1 / M2 / M3) systems using Docker.

It documents a reproducible Docker build failure and provides a verified
workaround using the official prebuilt Docker image.

---

### Problem Observed

On macOS Apple Silicon systems, building PyGoat locally using:

* `docker-compose up --build`
* `docker build`

may fail during the image build process.

The failure occurs at the `apt-get update` step with errors similar to:

```
404 Not Found
The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
```

This happens because the base Docker image relies on **Debian buster**, which has
reached end-of-life (EOL), causing package repositories to be unavailable.

---

### Why This Happens

* The local `Dockerfile` uses a Debian **buster**–based Python image
* Debian buster repositories are no longer served
* `apt-get update` fails during the build stage
* This issue is reproducible on macOS Apple Silicon (arm64) systems

---

### Documented Workaround

This PR documents a working approach that avoids rebuilding the image locally:

* Use the official prebuilt image: `pygoat/pygoat:latest`
* Explicitly specify the platform as `linux/amd64`

Example:

```bash
docker run --rm \
  --platform=linux/amd64 \
  -p 8000:8000 \
  pygoat/pygoat:latest
```

For Docker Compose users, the documentation clarifies how to configure this
in the `docker-compose.yml` file.

---

### Scope of Change

* ✅ Documentation-only
* ❌ No code changes
* ❌ No Dockerfile changes
* ❌ No configuration files modified

This PR only adds a scoped clarification to help macOS Apple Silicon users run
PyGoat successfully.

---

### Environment Used for Reproduction

* macOS (Apple Silicon, M2)
* Latest macOS version
* Docker Desktop (latest)
