### PR TITLE
Add KNOWN_ISSUES.md for SQLite Permission Behavior

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -68,8 +68,8 @@ For production deployments, consider using a named Docker volume instead of a bi
 services:
   migration:
     volumes:
-      - db_data:/app/db.sqlite3
       - .:/app
+      - db_data:/app/db.sqlite3
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
Documents the SQLite file permission behavior when running PyGoat via Docker, providing users with clear solutions for handling root-owned database files on Linux/macOS hosts.

## Problem
When running PyGoat through Docker Compose, `db.sqlite3` is created with `root:root` ownership due to containers running as the root user by default. This causes permission issues for non-root users attempting to delete or modify the database file on the host system.

## Changes
Created `KNOWN_ISSUES.md` with comprehensive documentation covering:
- Root cause analysis of the permission issue
- Four solution approaches with use-case recommendations:
  - Quick fix using sudo (immediate workaround)
  - Non-root user configuration (development environments)
  - Post-cleanup permission fixes (simple scripting)
  - Named Docker volumes (production recommendation)
- Clear guidance on which solution to use for different scenarios

## Testing
- Validated documentation accuracy against actual Docker behavior
- Verified all provided solutions are functional and correct
- Ensured markdown formatting renders properly


**Related Issues**
Addresses point 3 from #302 as requested by @RupakBiswas-2304 ([Comment](https://github.com/adeyosemanputra/pygoat/pull/302#issuecomment-3708758998))
This complements the previously merged fixes:

✅ Django documentation URL comments restored
✅ Auto-populate challenges hook implemented


### Additional Context
This is a documentation-only change with no code modifications. The issue itself is expected Docker behavior and doesn't require code changes, but documenting it improves developer experience and reduces friction during local development.