### PR TITLE
Fix SQL Injection Lab: Add missing space before AND keyword (#321)

### DIFF
--- a/introduction/templates/Lab/SQL/sql.html
+++ b/introduction/templates/Lab/SQL/sql.html
@@ -47,7 +47,7 @@
                 The website logs a user in by checking the entered username and password against the ones stored in the
                 database. If they match, the user is logged in.
                 Lets first analyse the sql query used to compare the username and password in the database.
-                <br><code>"SELECT * FROM introduction_login WHERE user='"+name+"'AND password='"+password+"'"</code><br>
+                <br><code>"SELECT * FROM introduction_login WHERE user='"+name+"' AND password='"+password+"'"</code><br>
                 The name and password parameters are the ones you give as input, which is directly inserted into the
                 query.<br>
 

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -154,7 +154,7 @@ def sql_lab(request):
 
             if login.objects.filter(user=name):
 
-                sql_query = "SELECT * FROM introduction_login WHERE user='"+name+"'AND password='"+password+"'"
+                sql_query = "SELECT * FROM introduction_login WHERE user='"+name+"' AND password='"+password+"'"
                 print(sql_query)
                 try:
                     print("\nin try\n")


### PR DESCRIPTION
Fixes #321 - SQL Injection Lab's missing space before AND keyword causing syntax errors.

## Problem
The SQL Injection Lab had a SQL syntax error due to missing space before the `AND` keyword in both the code and documentation.

**Current (broken):**
```sql
SELECT * FROM introduction_login WHERE user='admin'AND password='...'