### PR TITLE
Fix Command Injection lab URL sanitization to handle all bypass cases

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -411,7 +411,7 @@ def cmd_lab(request):
         if(request.method=="POST"):
             domain=request.POST.get('domain')
             # Remove all common protocols (case-insensitive) and www prefix
-            domain = re.sub(r'^(https?|ftp)://(www\.)?', '', domain, flags=re.IGNORECASE)
+            domain = re.sub(r'^(?:(https?|ftp)://)?(?:www\.)?', '', domain, flags=re.IGNORECASE)
             os=request.POST.get('os')
             print(os)
             if(os=='win'):


### PR DESCRIPTION
## Description
Fixes #323 

This PR addresses the incomplete URL sanitization in the Command Injection lab that allowed multiple bypass methods.

## Changes Made
- Replaced the incomplete `domain.replace("https://www.", '')` with a comprehensive regex-based sanitization
- Now handles HTTP, HTTPS, and FTP protocols with case-insensitive matching
- Supports both `www.` and non-`www.` URL formats
- Prevents all bypass cases mentioned in issue #323

## Before
```python
domain=domain.replace("https://www.",'')
```

## After
```python
# Remove all common protocols (case-insensitive) and www prefix
domain = re.sub(r'^(https?|ftp)://(www\.)?', '', domain, flags=re.IGNORECASE)
```

## Bypass Cases Fixed
✅ `http://www.example.com` → Now properly sanitized to `example.com`  
✅ `https://example.com` → Now properly sanitized to `example.com`  
✅ `HTTPS://WWW.example.com` → Now properly sanitized (case-insensitive)  
✅ `ftp://example.com` → Now properly sanitized to `example.com`  

## Testing
Tested locally with Python 3.13.7 and Django 4.2 on Windows 11 with various URL formats to confirm all bypasses are now prevented.

## Additional Notes
The `re` module is already imported in the views.py file, so no additional imports were needed.