### PR TITLE
fix: Replace deprecated datetime.utcnow() with timezone-aware datetime

### DIFF
--- a/introduction/mitre.py
+++ b/introduction/mitre.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 import re
 import subprocess
 from hashlib import md5
@@ -163,8 +164,8 @@ def csrf_lab_login(request):
         if User:
             payload ={
                 'username': username,
-                'exp': datetime.datetime.utcnow() + datetime.timedelta(seconds=300),
-                'iat': datetime.datetime.utcnow()
+                'exp': datetime.datetime.now(timezone.utc) + datetime.timedelta(seconds=300),
+                'iat': datetime.datetime.now(timezone.utc)
             }
             cookie = jwt.encode(payload, 'csrf_vulneribility', algorithm='HS256')
             response = redirect("/mitre/9/lab/transaction")

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -1,5 +1,6 @@
 import base64
 import datetime
+from datetime import timezone
 import hashlib
 import json
 import logging
@@ -1112,8 +1113,8 @@ def sec_misconfig_lab3(request):
     except:
         payload = {
             'user':'not_admin',
-            'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=60),
-            'iat': datetime.datetime.utcnow(),
+            'exp': datetime.datetime.now(timezone.utc) + datetime.timedelta(minutes=60),
+            'iat': datetime.datetime.now(timezone.utc),
         }
 
         cookie = jwt.encode(payload, SECRET_COOKIE_KEY, algorithm='HS256')


### PR DESCRIPTION
## Summary
Replaces deprecated `datetime.utcnow()` calls with the modern `datetime.now(timezone.utc)` alternative for Python 3.12+ compatibility.

## Changes
- Added `from datetime import timezone` import
- Replaced `datetime.datetime.utcnow()` → `datetime.datetime.now(timezone.utc)` in:
  - `introduction/views.py` (JWT generation in `sec_misconfig_lab3`)
  - `introduction/mitre.py` (JWT generation in `csrf_lab_login`)

## Why
`datetime.utcnow()` is deprecated in Python 3.12 and will be removed in a future version. The new method returns timezone-aware datetimes, which is the recommended practice.


Fixes #356 