### PR TITLE
fix: Rename `os` variable to avoid shadowing Python's os module in cmd_lab()

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -411,9 +411,9 @@ def cmd_lab(request):
         if(request.method=="POST"):
             domain=request.POST.get('domain')
             domain=domain.replace("https://www.",'')
-            os=request.POST.get('os')
-            print(os)
-            if(os=='win'):
+            os_type=request.POST.get('os')
+            print(os_type)
+            if(os_type=='win'):
                 command="nslookup {}".format(domain)
             else:
                 command = "dig {}".format(domain)


### PR DESCRIPTION
## Summary
Fixes a variable shadowing issue in `cmd_lab()` where a local variable named `os` was shadowing Python's built-in `os` module.

## Problem
In `introduction/views.py`, the `cmd_lab()` function had:
```python
os = request.POST.get('os')
```

This created a local variable `os` that shadowed the imported `os` module (line 6). While the current code doesn't use the `os` module after this assignment, this pattern is problematic because:

- **Future maintenance risk** — Any developer adding code that uses `os.path`, `os.environ`, etc. would encounter a confusing `AttributeError: 'str' object has no attribute 'path'`
- **Code clarity** — A variable named `os` containing a string like `'win'` or `'linux'` is misleading
- **Static analysis** — Linters and IDEs flag this as a code smell

## Solution
Renamed the variable from `os` to `os_type` in all three places it's used:

- **Line 414:** `os_type = request.POST.get('os')`
- **Line 415:** `print(os_type)`
- **Line 416:** `if(os_type == 'win'):`

This makes the code more maintainable and prevents potential bugs down the line.