### PR TITLE
fix: remove deprecated USE_L10N setting for Django 4.0+ compatibility

### DIFF
--- a/dockerized_labs/sensitive_data_exposure/sensitive_data_lab/settings.py
+++ b/dockerized_labs/sensitive_data_exposure/sensitive_data_lab/settings.py
@@ -82,7 +82,6 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)

--- a/pygoat/settings.py
+++ b/pygoat/settings.py
@@ -129,8 +129,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
# Remove Deprecated USE_L10N Setting

## Description

Removes the deprecated `USE_L10N` setting from Django settings files to eliminate deprecation warnings and ensure compatibility with Django 5.0+.

## Changes

- Removed `USE_L10N = True` from `pygoat/settings.py`
- Removed `USE_L10N = True` from `dockerized_labs/sensitive_data_exposure/sensitive_data_lab/settings.py`

## Why This Change?

| Django Version | USE_L10N Status |
|----------------|-----------------|
| Django < 4.0 | Active setting |
| Django 4.0+ | Deprecated (emits `RemovedInDjango50Warning`) |
| Django 5.0+ | Removed (causes error if present) |

Since Django 4.0, localization is always enabled by default, making `USE_L10N = True` a no-op that only produces deprecation warnings.

## Impact

**No functional changes.** The previous value (`True`) matches Django's new default behavior.

This is purely a cleanup to:
- Silence deprecation warnings
- Prepare for Django 5.0+ migration
- Follow current Django best practices