### PR TITLE
chore: remove deprecated version key from docker-compose files

### DIFF
--- a/challenge/labs/business_logic_lab/docker-compose.yml
+++ b/challenge/labs/business_logic_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   business_logic_lab:
     build: .

--- a/challenge/labs/security_headers_lab/docker-compose.yml
+++ b/challenge/labs/security_headers_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   security_headers_lab:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   migration:
     build: .

--- a/dockerized_labs/a9_uckv_lab/docker-compose.yml
+++ b/dockerized_labs/a9_uckv_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   web:
     build:

--- a/dockerized_labs/auth_failure_lab/docker-compose.yml
+++ b/dockerized_labs/auth_failure_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .

--- a/dockerized_labs/broken_auth_lab/docker-compose.yml
+++ b/dockerized_labs/broken_auth_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   broken_auth_lab:
     build: .

--- a/dockerized_labs/command_injection_lab/docker-compose.yml
+++ b/dockerized_labs/command_injection_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   command_injection_lab:
     build: .

--- a/dockerized_labs/crypto_failure_lab/docker-compose.yml
+++ b/dockerized_labs/crypto_failure_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   crypto_failure_lab:
     build: .

--- a/dockerized_labs/dependency_attack_lab/docker-compose.yml
+++ b/dockerized_labs/dependency_attack_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   dependency_attack_lab:
     build: .

--- a/dockerized_labs/insecure_design_lab/docker-compose.yml
+++ b/dockerized_labs/insecure_design_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     build: .

--- a/dockerized_labs/insufficient_logging_lab/docker-compose.yml
+++ b/dockerized_labs/insufficient_logging_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   insufficient_logging:
     build: .

--- a/dockerized_labs/open_source_library_attack_lab/docker-compose.yml
+++ b/dockerized_labs/open_source_library_attack_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   compromised_library_lab:
     build: .

--- a/dockerized_labs/package_injection_lab/docker-compose.yml
+++ b/dockerized_labs/package_injection_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   package_injection_lab:
     build: .

--- a/dockerized_labs/sde/docker-compose.yml
+++ b/dockerized_labs/sde/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .

--- a/dockerized_labs/sec_misconfig/docker-compose.yml
+++ b/dockerized_labs/sec_misconfig/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .

--- a/dockerized_labs/sensitive_data_exposure/docker-compose.yml
+++ b/dockerized_labs/sensitive_data_exposure/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     build: .

--- a/dockerized_labs/software_integrity_lab/docker-compose.yml
+++ b/dockerized_labs/software_integrity_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   software_integrity_lab:
     build: .

--- a/dockerized_labs/sql_injection_lab/docker-compose.yml
+++ b/dockerized_labs/sql_injection_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   sql_injection_lab:
     build: .

--- a/dockerized_labs/ssrf_lab/docker-compose.yml
+++ b/dockerized_labs/ssrf_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ssrf-lab:
     build: .

--- a/dockerized_labs/template_injection_lab/docker-compose.yml
+++ b/dockerized_labs/template_injection_lab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   template_injection:
     build: .

--- a/dockerized_labs/xss_lab/docker-compose.yml
+++ b/dockerized_labs/xss_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   xss_lab:
     build: .

--- a/dockerized_labs/xxe_lab/docker-compose.yml
+++ b/dockerized_labs/xxe_lab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     build: .


### PR DESCRIPTION
## Summary
Removes the deprecated `version` key from all 22 docker-compose.yml files.

## Why?
Docker Compose V2 (the default since 2023) ignores the `version` field entirely and emits deprecation warnings. The compose schema is now automatically detected from the features used.

## Changes
- Removed `version: "3.x"` from 22 files:
  - `docker-compose.yml` (root)
  - 18 files in `dockerized_labs/*/docker-compose.yml`
  - 2 files in `challenge/labs/*/docker-compose.yml`

## Impact
- Non-breaking change
- Backward compatible
- Removes deprecation warnings from logs