### PR TITLE
fix: add @wraps decorator to preserve function metadata in authentication_decorator

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -12,6 +12,7 @@ import string
 import subprocess
 import uuid
 from dataclasses import dataclass
+from functools import wraps
 from hashlib import md5
 from io import BytesIO
 from random import randint
@@ -96,15 +97,16 @@ def home(request):
         return redirect("login")
 
 
-## authentication check decurator function
+## authentication check decorator function
 def authentication_decorator(func):
-    def function(*args, **kwargs):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
         if args[0].user.is_authenticated:
             return func(*args, **kwargs)
         else:
             return redirect("login")
 
-    return function
+    return wrapper
 
 
 # *****************************************XSS****************************************************#


### PR DESCRIPTION
## Summary

Adds `functools.wraps` decorator to `authentication_decorator` to preserve function metadata when decorating views.

## Problem

The `authentication_decorator` function was missing the `@wraps` decorator, causing decorated functions to lose their metadata:

- `__name__` - Function name became `"function"` instead of the actual view name
- `__doc__` - Docstrings were lost
- `__module__`, `__annotations__`, `__qualname__` - All metadata was lost

This can cause issues with:
- Debugging (stack traces show generic names)
- Django admin introspection
- Logging systems that rely on function names
- Documentation generators
- Testing frameworks

## Changes

**File:** `introduction/views.py`

1. Added `from functools import wraps` import
2. Added `@wraps(func)` decorator to the inner wrapper function
3. Renamed inner function from `function` to `wrapper` (conventional naming)
4. Fixed typo in comment: "decurator" → "decorator"

## Before

def authentication_decorator(func):
    def function(*args, **kwargs):
        if args[0].user.is_authenticated:
            return func(*args, **kwargs)
        else:
            return redirect('login')
    return function

## After

from functools import wraps

def authentication_decorator(func):
    @ wraps(func)
    def wrapper(*args, **kwargs):
        if args[0].user.is_authenticated:
            return func(*args, **kwargs)
        else:
            return redirect('login')
    return wrapper
    
## Testing

- No linter errors
- Follows Python best practices for decorators
- Non-breaking change - authentication logic unchanged