### PR TITLE
fix: rename shadowed file handle variable in ssrf_lab 

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -918,8 +918,8 @@ def ssrf_lab(request):
             try :
                 dirname = os.path.dirname(__file__)
                 filename = os.path.join(dirname, file)
-                file = open(filename,"r")
-                data = file.read()
+                f = open(filename,"r")
+                data = f.read()
                 return render(request,"Lab/ssrf/ssrf_lab.html",{"blog":data})
             except:
                 return render(request, "Lab/ssrf/ssrf_lab.html", {"blog": "No blog found"})


### PR DESCRIPTION
## Summary
Rename the file handle variable from `file` to `f` in the `ssrf_lab` 
view to avoid shadowing the earlier `file = request.POST["blog"]` assignment.

## Problem
In `introduction/views.py`, the `ssrf_lab` function used `file` for both 
the POST request value and the file handle returned by `open()`, silently 
overwriting the original value.

## Changes
- Renamed `file` → `f` on the `open()` and `.read()` lines (lines 921–922)
- Pure rename, no behavior change