### PR TITLE
fix: use context managers for file handling to prevent resource leaks

### DIFF
--- a/introduction/utility.py
+++ b/introduction/utility.py
@@ -32,9 +32,8 @@ def ssrf_code_converter(code):
 
     dirname = os.path.dirname(__file__)
     filename = os.path.join(dirname, "playground/ssrf/main.py")
-    f = open(filename, "w")
-    f.write(output_Code)
-    f.close()
+    with open(filename, "w") as f:
+        f.write(output_Code)
     return 1
 
 

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -1164,8 +1164,8 @@ def ssrf_lab(request):
             try:
                 dirname = os.path.dirname(__file__)
                 filename = os.path.join(dirname, file)
-                file = open(filename, "r")
-                data = file.read()
+                with open(filename, "r") as f:
+                    data = f.read()
                 return render(request, "Lab/ssrf/ssrf_lab.html", {"blog": data})
             except:
                 return render(
@@ -1248,9 +1248,8 @@ def ssti_lab(request):
             filename = os.path.join(
                 dirname, f"templates/Lab_2021/A3_Injection/Blogs/{id}.html"
             )
-            file = open(filename, "w+")
-            file.write(blog)
-            file.close()
+            with open(filename, "w+") as file:
+                file.write(blog)
             return redirect(f"blog/{id}")
     else:
         return redirect("login")


### PR DESCRIPTION
## Summary

Replaced raw `open()` calls with `with` context managers to ensure files are always properly closed, even when exceptions occur.

## Problem

Several places in the codebase used `open()` without `with` statements:
- One location opened a file and **never closed it** at all
- Two other locations used manual `.close()` calls, which would be **skipped if an exception** was raised before reaching them

This can lead to:
- **File descriptor leaks** — `Too many open files` OS errors
- **Data loss** — buffered writes may never flush to disk
- **File locking issues** — unclosed files may remain locked on some platforms

## Changes

| File | Location | Change |
|------|----------|--------|
| `introduction/views.py` | SSRF lab (~line 921) | Wrapped file read in `with open(...) as f:` — previously had no `.close()` at all |
| `introduction/views.py` | SSTI blog lab (~line 989) | Replaced `open()` / `.write()` / `.close()` with `with open(...) as file:` |
| `introduction/utility.py` | SSRF utility (~line 35) | Replaced `open()` / `.write()` / `.close()` with `with open(...) as f:` |

## Testing

- No functional behavior change — files are opened and used the same way
- The only difference is that cleanup (closing) is now guaranteed by Python's context manager protocol