### PR TITLE
chore: upgrade PyYAML to 6.0.3 for improved security and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pyflakes==2.3.1
 PyJWT==2.4.0
 python3-openid==3.2.0
 pytz==2020.1
-PyYAML==5.1
+PyYAML==6.0.3
 requests==2.28.2
 requests-oauthlib==1.3.1
 sqlparse==0.3.1


### PR DESCRIPTION
### Summary

This PR upgrades PyYAML from 5.1 to 6.0.3.

### Why

- PyYAML 5.1 is outdated.
- Newer versions include security improvements and better compatibility with modern Python versions.
- Helps ensure long-term maintainability of the project dependencies.

### Testing

- Project installs successfully in a fresh virtual environment.
- Local server runs without issues.
- Core functionality verified (home page, login page load correctly).

No functional changes were made.
