### PR TITLE
chore: update Pillow and cffi for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ argon2-cffi-bindings==21.2.0
 asgiref==3.6.0
 black==26.1.0
 certifi==2022.12.7
-cffi==1.15.1
+cffi>=1.17.0
 charset-normalizer==3.0.1
 cryptography==39.0.1
 crispy-bootstrap4==2022.1
@@ -16,7 +16,7 @@ gunicorn==23.0.0
 idna==3.4
 mccabe==0.6.1
 oauthlib==3.2.2
-Pillow==9.4.0
+Pillow>=10.0.0
 pre_commit==4.5.1
 pycodestyle==2.7.0
 pycparser==2.21


### PR DESCRIPTION
"Updated requirements.txt to modernize the project for Python 3.13.

Pillow: Upgraded to support Python 3.13's updated internal structures and avoid build-time KeyErrors.

cffi: Upgraded to resolve compilation errors caused by the removal of deprecated C-API functions in the latest Python release."