### PR TITLE
Fix the UI in light theme

### DIFF
--- a/introduction/static/css/light.css
+++ b/introduction/static/css/light.css
@@ -413,6 +413,18 @@ h2 {
   text-align: center;
   padding: 13% 0 0 0;
 }
+#owasp10_2025 {
+  width: 90%;
+  background: #283036;
+  background: #4e93c7;
+  margin-top: 15px;
+  left: 5%;
+  height: 110px;
+  padding: 17px;
+  border-radius: 10px;
+  text-align: center;
+  padding: 13% 0 0 0;
+}
 #owasp10_2017 {
   width: 90%;
   margin-top: 15px;
@@ -431,6 +443,10 @@ h2 {
 }
 
 #OWASP10_2021 {
+  width: 95%;
+  padding-left: 5%;
+}
+#OWASP10_2025 {
   width: 95%;
   padding-left: 5%;
 }


### PR DESCRIPTION
Closes #389
The New Section OWASP TOP 10 2025 has UI inconsistency in light theme.

Root cause:
Missing css for the light theme after addition of new section.

Before:
<img width="1920" height="1080" alt="Screenshot_2026-02-24_03_40_25" src="https://github.com/user-attachments/assets/560cffb8-d0a7-4389-8a3b-d5264973cdb9" />

After:
<img width="1920" height="1080" alt="Screenshot_2026-02-24_13_39_34" src="https://github.com/user-attachments/assets/15e7f115-1d10-4f49-8237-0f26f26b3ba0" />

