### PR TITLE
docs: add PR and issue templates for standardized contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in PyGoat
+title: "[Bug]: "
+labels: bug, triage
+---
+
+## Summary
+
+<!-- A clear and concise description of the bug. -->
+
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+
+## Actual Behavior
+
+<!-- What actually happened. Include error messages or tracebacks if applicable. -->
+
+
+## Screenshots / Logs
+
+<!-- If applicable, paste screenshots or log output here. -->
+
+
+## Environment
+
+- **OS:** 
+- **Browser:** 
+- **Python version:** 
+- **Deployment method:** Docker / Docker Compose / Local (manage.py runserver)
+
+## Additional Context
+
+<!-- Any other relevant information. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: OWASP PyGoat Documentation
+    url: https://owasp.org/www-project-pygoat/
+    about: Check the official OWASP PyGoat page for documentation and resources.
+  - name: General Questions & Discussions
+    url: https://github.com/adeyosemanputra/pygoat/discussions
+    about: Ask questions and discuss ideas in GitHub Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for PyGoat
+title: "[Feature]: "
+labels: enhancement
+---
+
+## Problem Statement
+
+<!-- What problem does this feature solve? Is this related to a frustration with the current behavior? -->
+
+
+## Proposed Solution
+
+<!-- Describe the solution or behavior you'd like to see. -->
+
+
+## Alternatives Considered
+
+<!-- Describe any alternative solutions or workarounds you've considered. -->
+
+
+## Category
+
+<!-- Which area does this relate to? (e.g. New lab, Existing lab improvement, UI/UX, Docs, CI/CD, Docker/Deployment, Other) -->
+
+
+## Mockups / Screenshots
+
+<!-- If applicable, add mockups or screenshots to illustrate the feature. -->
+
+
+## Additional Context
+
+<!-- Any other context, references, or links. -->

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.md
@@ -1,0 +1,38 @@
+---
+name: Security Vulnerability (Non-Lab)
+about: Report a real security vulnerability in the PyGoat platform itself (NOT in an intentionally vulnerable lab)
+title: "[Security]: "
+labels: security, triage
+---
+
+> **Note:** This template is for real security issues in the PyGoat platform code, NOT for the intentionally vulnerable labs. For critical vulnerabilities, consider reaching out to the maintainers privately first.
+
+## Vulnerability Summary
+
+<!-- A brief description of the security issue. -->
+
+
+## Impact
+
+<!-- What is the potential impact? Who or what is affected? -->
+
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Suggested Remediation
+
+<!-- If you have a fix or suggestion, describe it here. -->
+
+
+## References
+
+<!-- Links to relevant CVEs, OWASP entries, or documentation. -->
+
+
+## Proof of Concept / Screenshots
+
+<!-- Attach screenshots, logs, or PoC code if applicable. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,69 @@
+## Summary
+
+<!-- Provide a concise description of the changes in this PR (1-3 sentences). -->
+
+
+## Problem / Motivation
+
+<!-- Why is this change necessary? Link any related issues (e.g. Fixes #123). -->
+
+Fixes #
+
+## Solution / Approach
+
+<!-- Describe what you changed and why you chose this approach. -->
+
+
+## Files Changed
+
+<!-- List the key files modified and briefly note what changed in each. -->
+
+| File | Change |
+|------|--------|
+| `path/to/file` | Brief description |
+
+## Type of Change
+
+<!-- Mark the relevant option with an "x". -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD or build configuration
+- [ ] Security fix
+
+## Impact
+
+<!-- What is the impact of this change? Consider: performance, security, UX, breaking changes, dependencies, etc. -->
+
+- 
+- 
+- 
+
+
+## Screenshots (if applicable)
+
+<!-- Attach before/after screenshots for UI changes. Delete this section if not applicable. -->
+
+| Before | After |
+|--------|-------|
+|        |       |
+
+
+## Commit Message Convention
+
+<!--
+Follow Linux-style commit messages:
+
+  <type>: <short summary in imperative mood>
+
+  <body - explain what and why, not how>
+
+  Fixes #<issue>
+  Signed-off-by: Your Name <email@example.com>
+
+Types: fix, feat, docs, refactor, test, ci, chore, security
+Example: fix: prevent SQL injection in login form
+-->


### PR DESCRIPTION
## Summary

Add GitHub PR template and issue templates to standardize how contributions and issues are submitted to the project.

## Problem / Motivation

The repository currently has no PR or issue templates, which leads to inconsistent submissions; missing context, no reproduction steps on bugs, and no structured format for pull requests. This makes reviewing harder for maintainers.


## Solution / Approach

Added industry-standard GitHub templates following open-source best practices (Linux-style commit conventions, structured sections for context and reasoning):

- **PR template** with sections for Summary, Problem/Motivation, Solution, Files Changed, Type of Change, Impact, Screenshots, and Checklist
- **Issue templates** (markdown-based, no YAML forms) for Bug Reports, Feature Requests, and Security Vulnerabilities
- **Issue chooser config** with contact links to OWASP docs and GitHub Discussions

## Files Changed

| File | Change |
|------|--------|
| `.github/PULL_REQUEST_TEMPLATE.md` | New PR template with structured sections |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug report template with reproduction steps, environment info |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature request template with problem/solution framing |
| `.github/ISSUE_TEMPLATE/security_vulnerability.md` | Security vulnerability report (non-lab, real platform issues) |
| `.github/ISSUE_TEMPLATE/config.yml` | Issue chooser config with contact links |

## Type of Change

- [x] Documentation update

## Impact

- Standardizes all future PRs and issues across the project
- Reduces back-and-forth between contributors and maintainers
- Guides first-time contributors with clear structure
