### PR TITLE
UI: Updated button text for better understing of theme switcher

### DIFF
--- a/introduction/templates/introduction/base.html
+++ b/introduction/templates/introduction/base.html
@@ -865,11 +865,13 @@
             elem.classList.add('light');
             localStorage.setItem('theme','light');
             document.getElementById("pagestyle").setAttribute("href", "/static/css/light.css");
+            elem.innerText = "Dark 🌙";
         } else {
             elem.classList.remove('light');
             elem.classList.add('dark');
             localStorage.setItem('theme','dark');
             document.getElementById("pagestyle").setAttribute("href", "/static/css/dark-theme.css");
+            elem.innerText = "Light ☀️";
         } 
       }
       var elem3 = document.getElementById('stylesheet-toggle');
@@ -877,6 +879,12 @@
         elem3.classList.remove('dark');
         elem3.classList.add('light');
         document.getElementById("pagestyle").setAttribute("href", "/static/css/light.css");
+        elem3.innerText = "Dark 🌙";
+      }else {
+        elem3.classList.remove('light');
+        elem3.classList.add('dark');
+        document.getElementById("pagestyle").setAttribute("href", "/static/css/dark-theme.css");
+        elem3.innerText = "Light ☀️";
       }
       
     </script>


### PR DESCRIPTION
noticed the theme button is bit confusing as it only contain theme text inside . So, i updated it to **dark theme** and **light theme** .
when we were in light theme it show  **Dark** : which indicates switch to dark  and when we were in Dark theme it show  **Light** :which indicates switch to light theme

<img width="1884" height="858" alt="Screenshot 2026-03-09 200707" src="https://github.com/user-attachments/assets/a312e8ce-3b78-4e07-90ba-cd5eeb8e17e1" />
<img width="1892" height="859" alt="Screenshot 2026-03-09 200654" src="https://github.com/user-attachments/assets/b833c012-33b2-412d-beba-248a994a8609" />

