### PR TITLE
Implemented Traefik Forward Auth

### DIFF
--- a/challenge/views.py
+++ b/challenge/views.py
@@ -249,6 +249,10 @@ def start_lab(request, lab_image_name):
                 "traefik.enable": "true",
                 f"traefik.http.routers.{container_name}.rule": f"Host(`{container_name}.{domain}`)",
                 f"traefik.http.services.{container_name}.loadbalancer.server.port": lab_port,
+                "traefik.http.middlewares.django-auth.forwardauth.address": "http://web:8000/auth/verify/",
+                "traefik.http.middlewares.django-auth.forwardauth.trustForwardHeader": "true",
+                "traefik.http.middlewares.django-auth.forwardauth.authResponseHeaders": "X-Forwarded-User",
+                f"traefik.http.routers.{container_name}.middlewares":"django-auth",
             }
             healthcheck = docker.types.Healthcheck(
             test=[

--- a/introduction/urls.py
+++ b/introduction/urls.py
@@ -7,6 +7,7 @@ from . import apis, mitre, views
 urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("", views.home, name="homepage"),
+    path('auth/verify/', views.traefik_auth_verify, name='traefik-verify'),
     path("xss", views.xss, name="xss"),
     path("xssL", views.xss_lab, name="xss_lab"),
     path("xssL2", views.xss_lab2, name="xss_lab2"),

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -106,7 +106,33 @@ def authentication_decorator(func):
 
     return function
 
+def traefik_auth_verify(request):
+    if not request.user.is_authenticated:
+        return HttpResponse(status=401)
 
+    host = request.headers.get("X-Forwarded-Host") or request.get_host()
+    if not host or "." not in host:
+        return HttpResponseBadRequest("Invalid host header")
+    subdomain = host.split(".")[0]
+
+    if not subdomain.startswith("lab-"):
+        return HttpResponse(status=403)
+
+    parts = subdomain.split("-")
+
+    if len(parts) < 3:
+        return HttpResponse(status=403)
+
+    username_from_host = parts[1]
+    if not re.fullmatch(r"[A-Za-z0-9_]+", username_from_host):
+        return HttpResponse(status=403)
+
+    if request.user.username != username_from_host:
+        return HttpResponse(status=403)
+
+    response = HttpResponse(status=200)
+    response["X-Forwarded-User"] = request.user.username
+    return response
 # *****************************************XSS****************************************************#
 
 

--- a/pygoat/settings.py
+++ b/pygoat/settings.py
@@ -27,7 +27,7 @@ SENSITIVE_DATA = "FLAGTHATNEEDSTOBEFOUND"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["pygoat.herokuapp.com", "0.0.0.0", "127.0.0.1", "localhost"]
+ALLOWED_HOSTS = ["pygoat.herokuapp.com", "0.0.0.0", "127.0.0.1", "localhost", "lvh.me", ".lvh.me", "web"]
 
 
 # Application definition
@@ -174,14 +174,25 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 SECRET_COOKIE_KEY = "PYGOAT"
-CSRF_TRUSTED_ORIGINS = ["http://127.0.0.1:8000","http://0.0.0.0:8000","http://172.16.189.10"]
+CSRF_TRUSTED_ORIGINS = [
+    "http://127.0.0.1:8000",
+    "http://0.0.0.0:8000",
+    "http://172.16.189.10",
+    "http://lvh.me:8000",
+    "http://lvh.me",
+    "http://*.lvh.me",
+]
 
 TRAEFIK_URLS = [
     'http://localhost:8080/api/http/routers',     
     'http://traefik_proxy:8080/api/http/routers',
 ]
 
-# Labs configuration
-# LAB_DOMAIN = "localhost"
+LAB_DOMAIN = "lvh.me"
 # DOCKER_NETWORK = "my_network"
 # LABS_PER_USER_LIMIT = 3
+
+SESSION_COOKIE_DOMAIN = ".lvh.me"
+CSRF_COOKIE_DOMAIN = ".lvh.me"
+SESSION_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_SAMESITE = "Lax"


### PR DESCRIPTION
Closes #396 
## Add Traefik ForwardAuth for per-user lab access via subdomains

### Overview
This PR integrates **Traefik ForwardAuth** with Django to enforce authentication and authorization for dynamically created lab containers accessed via subdomains.

### Key Changes

#### 1. Traefik ForwardAuth Middleware
- Added Traefik middleware configuration when creating lab containers in `challenge/views.py`.
- Requests to lab containers are now validated through Django using the `/auth/verify/` endpoint.

#### 2. Authentication Verification Endpoint
- Implemented `traefik_auth_verify` view in `introduction/views.py`.
- The endpoint verifies:
  - The user is authenticated.
  - The request originates from a valid lab subdomain (`lab-<username>-*`).
  - The username in the subdomain matches the logged-in user.
- On success, the endpoint returns `200` with the `X-Forwarded-User` header.

#### 3. Routing
- Added new route:
  - `/auth/verify/` → `traefik_auth_verify`
- Defined in `introduction/urls.py`.

#### 4. Subdomain and Cookie Support
- Configured `LAB_DOMAIN = "lvh.me"` for wildcard subdomains in local development.
- Updated `ALLOWED_HOSTS` to allow `lvh.me` and its subdomains.
- Updated `CSRF_TRUSTED_ORIGINS` to support `*.lvh.me`.
- Added shared cookie configuration:
  - `SESSION_COOKIE_DOMAIN = ".lvh.me"`
  - `CSRF_COOKIE_DOMAIN = ".lvh.me"`
  - `SESSION_COOKIE_SAMESITE = "Lax"`
  - `CSRF_COOKIE_SAMESITE = "Lax"`

### Result
Lab containers are now protected so that **only the authenticated user who owns the lab subdomain can access it**, preventing cross-user access and improving lab isolation.

### Testing
- Start a lab container → accessible via `lab-<username>-<id>.lvh.me`
- Authenticated user with matching username → **200 OK**
- Unauthenticated user → **401 Unauthorized**
- Authenticated user with mismatched username → **403 Forbidden**