### PR TITLE
fix: persist sidebar state across page navigations using localStorage

### DIFF
--- a/introduction/templates/introduction/base.html
+++ b/introduction/templates/introduction/base.html
@@ -64,7 +64,7 @@
 
         <ul class="list-unstyled components" style="margin-bottom: 0px;">
           <li >
-            <a
+            
               href="#homeSubmenu"
               data-toggle="collapse"
               aria-expanded="false"
@@ -82,7 +82,7 @@
             </ul>
           </li>
           <li>
-            <a
+            
               href="#OWASP10_2021"
               data-toggle="collapse"
               aria-expanded="false"
@@ -107,7 +107,7 @@
                 </a>
               </li>
               <li>
-                <a
+                
                   href="#sqlSubmenu2"
                   data-toggle="collapse"
                   aria-expanded="false"
@@ -118,19 +118,13 @@
                 </a>
                 <ul class="collapse list-unstyled" id="sqlSubmenu2">
                   <li>
-                    <a href="/injection" class="sidebar-list-items"
-                      >SQl Injection
-                    </a>
+                    <a href="/injection" class="sidebar-list-items">SQl Injection</a>
                   </li>
                   <li>
-                    <a href="/cmd" class="sidebar-list-items"
-                      >Command Injection</a
-                    >
+                    <a href="/cmd" class="sidebar-list-items">Command Injection</a>
                   </li>
                   <li>
-                    <a href="/ssti" class="sidebar-list-items"
-                      >Template Injection</a
-                    >
+                    <a href="/ssti" class="sidebar-list-items">Template Injection</a>
                   </li>
                 </ul>
               </li>
@@ -178,7 +172,7 @@
               </li>
             </ul>
 
-            <a
+            
               href="#sans25"
               data-toggle="collapse"
               aria-expanded="false"
@@ -190,162 +184,34 @@
               SANS 25 Vulns
             </a>
             <ul class="collapse list-unstyled" id="sans25">
-              <li>
-                <a href="/mitre/1" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                   S1 : Out-of-bounds Write
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/2" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                   S2 : Improper Neutralization of Input During Web Page Generation 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/3" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S3 : SQL Injection
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/4" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S4 : Improper Input Validation 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/5" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S5 : Out of bounds write
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/6" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S6 : OS Command Injection 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/7" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S7 : Use After Free 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/8" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S8 : Path Traversal
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/9" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S9 : CSRF
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/10" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S10 : Unrestricted Upload of File with Dangerous Type
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/11" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S11 : Null Pointer Referernece
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/12" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S12 : Deserialization of Untrusted Data
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/13" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  S13 : Interger Overflow or  Wraparround
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/14" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                 S14 : Improper Authentication 
-                </a>
-              </li>
-              
-              <li>
-                <a href="/mitre/15" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                 S15 : User of Hardcoded credential 
-                </a>
-              </li>
+              <li><a href="/mitre/1" class="sidebar-list-items"><i class="fas fa-bug"></i> S1 : Out-of-bounds Write</a></li>
+              <li><a href="/mitre/2" class="sidebar-list-items"><i class="fas fa-bug"></i> S2 : Improper Neutralization of Input During Web Page Generation</a></li>
+              <li><a href="/mitre/3" class="sidebar-list-items"><i class="fas fa-bug"></i> S3 : SQL Injection</a></li>
+              <li><a href="/mitre/4" class="sidebar-list-items"><i class="fas fa-bug"></i> S4 : Improper Input Validation</a></li>
+              <li><a href="/mitre/5" class="sidebar-list-items"><i class="fas fa-bug"></i> S5 : Out of bounds write</a></li>
+              <li><a href="/mitre/6" class="sidebar-list-items"><i class="fas fa-bug"></i> S6 : OS Command Injection</a></li>
+              <li><a href="/mitre/7" class="sidebar-list-items"><i class="fas fa-bug"></i> S7 : Use After Free</a></li>
+              <li><a href="/mitre/8" class="sidebar-list-items"><i class="fas fa-bug"></i> S8 : Path Traversal</a></li>
+              <li><a href="/mitre/9" class="sidebar-list-items"><i class="fas fa-bug"></i> S9 : CSRF</a></li>
+              <li><a href="/mitre/10" class="sidebar-list-items"><i class="fas fa-bug"></i> S10 : Unrestricted Upload of File with Dangerous Type</a></li>
+              <li><a href="/mitre/11" class="sidebar-list-items"><i class="fas fa-bug"></i> S11 : Null Pointer Reference</a></li>
+              <li><a href="/mitre/12" class="sidebar-list-items"><i class="fas fa-bug"></i> S12 : Deserialization of Untrusted Data</a></li>
+              <li><a href="/mitre/13" class="sidebar-list-items"><i class="fas fa-bug"></i> S13 : Integer Overflow or Wraparound</a></li>
+              <li><a href="/mitre/14" class="sidebar-list-items"><i class="fas fa-bug"></i> S14 : Improper Authentication</a></li>
+              <li><a href="/mitre/15" class="sidebar-list-items"><i class="fas fa-bug"></i> S15 : Use of Hardcoded Credentials</a></li>
+              <li><a href="/mitre/16" class="sidebar-list-items"><i class="fas fa-bug"></i> S16 : Missing Authorization</a></li>
+              <li><a href="/mitre/17" class="sidebar-list-items"><i class="fas fa-bug"></i> S17 : Command Injection</a></li>
+              <li><a href="/mitre/18" class="sidebar-list-items"><i class="fas fa-bug"></i> S18 : Missing Authentication for Critical Function</a></li>
+              <li><a href="/mitre/19" class="sidebar-list-items"><i class="fas fa-bug"></i> S19 : Improper Restriction of Operations within the Bounds of a Memory Buffer</a></li>
+              <li><a href="/mitre/20" class="sidebar-list-items"><i class="fas fa-bug"></i> S20 : Incorrect Default Permission</a></li>
+              <li><a href="/mitre/21" class="sidebar-list-items"><i class="fas fa-bug"></i> S21 : Server Side Request Forgery</a></li>
+              <li><a href="/mitre/22" class="sidebar-list-items"><i class="fas fa-bug"></i> S22 : Concurrent Execution using Shared Resource with Improper Synchronization</a></li>
+              <li><a href="/mitre/23" class="sidebar-list-items"><i class="fas fa-bug"></i> S23 : Uncontrolled Resource Consumption</a></li>
+              <li><a href="/mitre/24" class="sidebar-list-items"><i class="fas fa-bug"></i> S24 : Improper Restriction of XML External Entity Reference</a></li>
+              <li><a href="/mitre/25" class="sidebar-list-items"><i class="fas fa-bug"></i> S25 : Code Injection</a></li>
+            </ul>
 
-              <li>
-                <a href="/mitre/16" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S16 : Missing Autherization 
-                </a>
-              </li>
-              
-              <li>
-                <a href="/mitre/17" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S17 : Command Injection 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/18" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S18 : Missing Authentication for Critical Function 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/19" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                 S19 : 	Improper Restriction of Operations within the Bounds of a Memory Buffer
-                </a>
-              </li>
-
-              <li>
-                <a href="/mitre/20" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S20 : Incorrect Default Permission
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/21" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S21 : Server Side Request Forgery 
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/22" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S22 : Concurrent Execution using Shared Resource with Improper Synchronization  
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/23" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S23 : Uncontrolled Resource Comsumption
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/24" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S24 : Improper Restriction of XML External Entity Reference
-                </a>
-              </li>
-              <li>
-                <a href="/mitre/25" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                S25 : Code Injection  
-                </a>
-              </li>
-          </ul>
-            <a
+            
               href="#Mitre25"
               data-toggle="collapse"
               aria-expanded="false"
@@ -357,162 +223,34 @@
               Mitre top 25 Vulns
             </a>
             <ul class="collapse list-unstyled" id="Mitre25">
-                <li>
-                  <a href="/mitre/1" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                     M1 : Out-of-bounds Write
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/2" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                     M2 : Improper Neutralization of Input During Web Page Generation 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/3" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M3 : SQL Injection
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/4" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M4 : Improper Input Validation 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/5" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M5 : Out of bounds write
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/6" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M6 : OS Command Injection 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/7" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M7 : Use After Free 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/8" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M8 : Path Traversal
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/9" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M9 : CSRF
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/10" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M10 : Unrestricted Upload of File with Dangerous Type
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/11" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M11 : Null Pointer Referernece
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/12" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M12 : Deserialization of Untrusted Data
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/13" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                    M13 : Interger Overflow or  Wraparround
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/14" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                   M14 : Improper Authentication 
-                  </a>
-                </li>
-                
-                <li>
-                  <a href="/mitre/15" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                   M15 : User of Hardcoded credential 
-                  </a>
-                </li>
-
-                <li>
-                  <a href="/mitre/16" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M16 : Missing Autherization 
-                  </a>
-                </li>
-                
-                <li>
-                  <a href="/mitre/17" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M17 : Command Injection 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/18" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M18 : Missing Authentication for Critical Function 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/19" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                   M19 : 	Improper Restriction of Operations within the Bounds of a Memory Buffer
-                  </a>
-                </li>
-
-                <li>
-                  <a href="/mitre/20" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M20 : Incorrect Default Permission
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/21" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M21 : Server Side Request Forgery 
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/22" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M22 : Concurrent Execution using Shared Resource with Improper Synchronization  
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/23" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M23 : Uncontrolled Resource Comsumption
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/24" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M24 : Improper Restriction of XML External Entity Reference
-                  </a>
-                </li>
-                <li>
-                  <a href="/mitre/25" class="sidebar-list-items">
-                    <i class="fas fa-bug"></i>
-                  M25 : Code Injection  
-                  </a>
-                </li>
+              <li><a href="/mitre/1" class="sidebar-list-items"><i class="fas fa-bug"></i> M1 : Out-of-bounds Write</a></li>
+              <li><a href="/mitre/2" class="sidebar-list-items"><i class="fas fa-bug"></i> M2 : Improper Neutralization of Input During Web Page Generation</a></li>
+              <li><a href="/mitre/3" class="sidebar-list-items"><i class="fas fa-bug"></i> M3 : SQL Injection</a></li>
+              <li><a href="/mitre/4" class="sidebar-list-items"><i class="fas fa-bug"></i> M4 : Improper Input Validation</a></li>
+              <li><a href="/mitre/5" class="sidebar-list-items"><i class="fas fa-bug"></i> M5 : Out of bounds write</a></li>
+              <li><a href="/mitre/6" class="sidebar-list-items"><i class="fas fa-bug"></i> M6 : OS Command Injection</a></li>
+              <li><a href="/mitre/7" class="sidebar-list-items"><i class="fas fa-bug"></i> M7 : Use After Free</a></li>
+              <li><a href="/mitre/8" class="sidebar-list-items"><i class="fas fa-bug"></i> M8 : Path Traversal</a></li>
+              <li><a href="/mitre/9" class="sidebar-list-items"><i class="fas fa-bug"></i> M9 : CSRF</a></li>
+              <li><a href="/mitre/10" class="sidebar-list-items"><i class="fas fa-bug"></i> M10 : Unrestricted Upload of File with Dangerous Type</a></li>
+              <li><a href="/mitre/11" class="sidebar-list-items"><i class="fas fa-bug"></i> M11 : Null Pointer Reference</a></li>
+              <li><a href="/mitre/12" class="sidebar-list-items"><i class="fas fa-bug"></i> M12 : Deserialization of Untrusted Data</a></li>
+              <li><a href="/mitre/13" class="sidebar-list-items"><i class="fas fa-bug"></i> M13 : Integer Overflow or Wraparound</a></li>
+              <li><a href="/mitre/14" class="sidebar-list-items"><i class="fas fa-bug"></i> M14 : Improper Authentication</a></li>
+              <li><a href="/mitre/15" class="sidebar-list-items"><i class="fas fa-bug"></i> M15 : Use of Hardcoded Credentials</a></li>
+              <li><a href="/mitre/16" class="sidebar-list-items"><i class="fas fa-bug"></i> M16 : Missing Authorization</a></li>
+              <li><a href="/mitre/17" class="sidebar-list-items"><i class="fas fa-bug"></i> M17 : Command Injection</a></li>
+              <li><a href="/mitre/18" class="sidebar-list-items"><i class="fas fa-bug"></i> M18 : Missing Authentication for Critical Function</a></li>
+              <li><a href="/mitre/19" class="sidebar-list-items"><i class="fas fa-bug"></i> M19 : Improper Restriction of Operations within the Bounds of a Memory Buffer</a></li>
+              <li><a href="/mitre/20" class="sidebar-list-items"><i class="fas fa-bug"></i> M20 : Incorrect Default Permission</a></li>
+              <li><a href="/mitre/21" class="sidebar-list-items"><i class="fas fa-bug"></i> M21 : Server Side Request Forgery</a></li>
+              <li><a href="/mitre/22" class="sidebar-list-items"><i class="fas fa-bug"></i> M22 : Concurrent Execution using Shared Resource with Improper Synchronization</a></li>
+              <li><a href="/mitre/23" class="sidebar-list-items"><i class="fas fa-bug"></i> M23 : Uncontrolled Resource Consumption</a></li>
+              <li><a href="/mitre/24" class="sidebar-list-items"><i class="fas fa-bug"></i> M24 : Improper Restriction of XML External Entity Reference</a></li>
+              <li><a href="/mitre/25" class="sidebar-list-items"><i class="fas fa-bug"></i> M25 : Code Injection</a></li>
             </ul>
-            <a
+
+            
               href="#OWASP10_2017"
               data-toggle="collapse"
               aria-expanded="false"
@@ -531,76 +269,21 @@
                 </a>
               </li>
               <ul class="collapse list-unstyled" id="sqlSubmenu">
-                <li>
-                  <a href="/sql" class="sidebar-list-items">SQl Injection </a>
-                </li>
-                <li>
-                  <a href="/cmd" class="sidebar-list-items"
-                    >Command Injection</a
-                  >
-                </li>
+                <li><a href="/sql" class="sidebar-list-items">SQl Injection</a></li>
+                <li><a href="/cmd" class="sidebar-list-items">Command Injection</a></li>
               </ul>
-              <li>
-                <a href="/bau" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A2: Broken Authentication
-                </a>
-              </li>
-              <li>
-                <a
-                  href="/data_exp"
-                  
-                  class="sidebar-list-items"
-                >
-                  <i class="fas fa-bug"></i>
-                  A3: Sensitive Data Exposure
-                </a>
-              </li>
-              <li>
-                <a href="/xxe" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A4: XML External Entities (XXE)
-                </a>
-              </li>
-              <li>
-                <a href="/ba" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A5: Broken Access Control
-                </a>
-              </li>
-              <li>
-                <a href="/sec_mis" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A6: Security Misconfiguration
-                </a>
-              </li>
-              <li>
-                <a href="/xss" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A7: Cross Site Scripting
-                </a>
-              </li>
-              <li>
-                <a href="/insec_des" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A8: Insecure Deserialization
-                </a>
-              </li>
-              <li>
-                <a href="/a9" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A9: Using Components with Known Vulnerabilities
-                </a>
-              </li>
-              <li>
-                <a href="/a10" class="sidebar-list-items">
-                  <i class="fas fa-bug"></i>
-                  A10: Insufficient Logging & Monitoring
-                </a>
-              </li>
+              <li><a href="/bau" class="sidebar-list-items"><i class="fas fa-bug"></i> A2: Broken Authentication</a></li>
+              <li><a href="/data_exp" class="sidebar-list-items"><i class="fas fa-bug"></i> A3: Sensitive Data Exposure</a></li>
+              <li><a href="/xxe" class="sidebar-list-items"><i class="fas fa-bug"></i> A4: XML External Entities (XXE)</a></li>
+              <li><a href="/ba" class="sidebar-list-items"><i class="fas fa-bug"></i> A5: Broken Access Control</a></li>
+              <li><a href="/sec_mis" class="sidebar-list-items"><i class="fas fa-bug"></i> A6: Security Misconfiguration</a></li>
+              <li><a href="/xss" class="sidebar-list-items"><i class="fas fa-bug"></i> A7: Cross Site Scripting</a></li>
+              <li><a href="/insec_des" class="sidebar-list-items"><i class="fas fa-bug"></i> A8: Insecure Deserialization</a></li>
+              <li><a href="/a9" class="sidebar-list-items"><i class="fas fa-bug"></i> A9: Using Components with Known Vulnerabilities</a></li>
+              <li><a href="/a10" class="sidebar-list-items"><i class="fas fa-bug"></i> A10: Insufficient Logging & Monitoring</a></li>
             </ul>
 
-            <a
+            
               href="#challengeSubmenu"
               data-toggle="collapse"
               aria-expanded="false"
@@ -616,7 +299,7 @@
                 <a href="/challenge/do-it-fast" class="sidebar-list-items">Do It Fast</a>
               </li>
             </ul>
-            <a
+            
               href="#"
               data-toggle="collapse"
               aria-expanded="false"
@@ -654,26 +337,17 @@
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
               <ul class="nav navbar-nav ml-auto">
                 <li class="nav-item">
-                  <button class="nav-link dark" href='{% url "logout" %}?next=/' id="stylesheet-toggle" onclick="swapStyleSheet()"
-                    >Theme</button
-                  >
+                  <button class="nav-link dark" href='{% url "logout" %}?next=/' id="stylesheet-toggle" onclick="swapStyleSheet()">Theme</button>
                 </li>
-
-
                 {% if user.is_authenticated %}
                 <li class="nav-item">
-                  <a class="nav-link" href='{% url "logout" %}?next=/'
-                    >Logout</a
-                  >
+                  <a class="nav-link" href='{% url "logout" %}?next=/'>Logout</a>
                 </li>
-
                 {% else %}
-
                 <li class="nav-item">
                   <a class="nav-link" href="/login">Login</a>
                 </li>
                 {% endif %}
-
               </ul>
             </div>
           </div>
@@ -683,7 +357,7 @@
       </div>
     </div>
 
-    <!-- jQuery CDN - Slim version (=without AJAX) -->
+    <!-- jQuery CDN -->
     <script
       src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
       integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
@@ -703,41 +377,79 @@
     ></script>
 
     <script type="text/javascript">
+
+      // Save sidebar state function
+      function saveSidebarState() {
+        if ($("#sidebar").hasClass("active")) {
+          localStorage.setItem('sidebarState', 'collapsed');
+        } else {
+          localStorage.setItem('sidebarState', 'expanded');
+        }
+      }
+
+      // Restore sidebar state on page load
+      $(document).ready(function () {
+        var sidebarState = localStorage.getItem('sidebarState');
+        if (sidebarState === 'collapsed') {
+          $("#sidebar").addClass("active");
+          $(".pg").addClass("active");
+        } else if (sidebarState === 'expanded') {
+          $("#sidebar").removeClass("active");
+          $(".pg").removeClass("active");
+        }
+      });
+
+      // Sidebar header click
       $(document).ready(function () {
         $(".sidebar-header").on("click", function () {
           $("#sidebar").toggleClass("active");
           $(".pg").toggleClass("active");
+          saveSidebarState();
         });
       });
 
+      // PG button click
       $(document).ready(function () {
         $(".pg").on("click", function () {
           $("#sidebar").toggleClass("active");
           $(".pg").toggleClass("active");
+          saveSidebarState();
         });
       });
 
+      // Toggle Sidebar button click
+      $(document).ready(function () {
+        $("#sidebarCollapse").on("click", function () {
+          $("#sidebar").toggleClass("active");
+          $(".pg").toggleClass("active");
+          saveSidebarState();
+        });
+      });
+
+      // Theme toggle
       function swapStyleSheet() {
         var elem = document.getElementById('stylesheet-toggle');
         if(elem.classList.contains('dark')){
-            elem.classList.remove('dark');
-            elem.classList.add('light');
-            localStorage.setItem('theme','light');
-            document.getElementById("pagestyle").setAttribute("href", "/static/css/light.css");
+          elem.classList.remove('dark');
+          elem.classList.add('light');
+          localStorage.setItem('theme','light');
+          document.getElementById("pagestyle").setAttribute("href", "/static/css/light.css");
         } else {
-            elem.classList.remove('light');
-            elem.classList.add('dark');
-            localStorage.setItem('theme','dark');
-            document.getElementById("pagestyle").setAttribute("href", "/static/css/dark-theme.css");
-        } 
+          elem.classList.remove('light');
+          elem.classList.add('dark');
+          localStorage.setItem('theme','dark');
+          document.getElementById("pagestyle").setAttribute("href", "/static/css/dark-theme.css");
+        }
       }
+
+      // Restore theme on page load
       var elem3 = document.getElementById('stylesheet-toggle');
       if(localStorage.getItem('theme')=='light') {
         elem3.classList.remove('dark');
         elem3.classList.add('light');
         document.getElementById("pagestyle").setAttribute("href", "/static/css/light.css");
       }
-      
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #360

## Problem
Sidebar collapsed/expanded state was lost on every page navigation.

## Solution
- Added localStorage to save sidebar state on every toggle
- State is restored automatically on page load
- Works for all 3 toggle methods:
  - Sidebar header click
  - PG button click  
  - Toggle Sidebar button click

## Changes
- Modified `introduction/templates/introduction/base.html`
- Added `saveSidebarState()` function
- Added state restore logic on `$(document).ready()`

## Testing
1. Open PyGoat
2. Toggle sidebar open/closed
3. Navigate to any page
4. Sidebar state is preserved ✅