### PR TITLE
Fix SQL Injection vulnerability in sql_lab and injection_sql_lab by replacing raw SQL with Django ORM

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -153,34 +153,23 @@ def sql_lab(request):
 
         if name:
 
-            if login.objects.filter(user=name):
+        if login.objects.filter(user=name):
+          user_obj = login.objects.filter(user=name, password=password).first()
 
-                sql_query = "SELECT * FROM introduction_login WHERE user='"+name+"' AND password='"+password+"'"
-                print(sql_query)
-                try:
-                    print("\nin try\n")
-                    val=login.objects.raw(sql_query)
-                except:
-                    print("\nin except\n")
-                    return render(
-                        request, 
-                        'Lab/SQL/sql_lab.html',
-                        {
-                            "wrongpass":password,
-                            "sql_error":sql_query
-                        })
+        if user_obj:
+          user = user_obj.user
+           return render(request, 'Lab/SQL/sql_lab.html', {"user1": user})
+         else:
+          return render(
+        request,
+        'Lab/SQL/sql_lab.html',
+        {
+            "wrongpass": password,
+            "sql_error": "Invalid credentials"
+        })
+                
 
-                if val:
-                    user=val[0].user
-                    return render(request, 'Lab/SQL/sql_lab.html',{"user1":user})
-                else:
-                    return render(
-                        request, 
-                        'Lab/SQL/sql_lab.html',
-                        {
-                            "wrongpass":password,
-                            "sql_error":sql_query
-                        })
+                
             else:
                 return render(request, 'Lab/SQL/sql_lab.html',{"no": "User not found"})
         else:
@@ -861,7 +850,7 @@ def injection_sql_lab(request):
         print(password)
 
         if name:
-            sql_query = "SELECT * FROM introduction_sql_lab_table WHERE id='"+name+"'AND password='"+password+"'"
+            user_obj = sql_lab_table.objects.filter(id=name, password=password).first()
 
             sql_instance = sql_lab_table(id="admin", password="65079b006e85a7e798abecb99e47c154")
             sql_instance.save()
@@ -872,11 +861,11 @@ def injection_sql_lab(request):
             sql_instance = sql_lab_table(id="bloke", password="f8d1ce191319ea8f4d1d26e65e130dd5")
             sql_instance.save()
 
-            print(sql_query)
+           
 
             try:
-                user = sql_lab_table.objects.raw(sql_query)
-                user = user[0].id
+              if user_obj:
+                user = user_obj.id
                 print(user)
 
             except:
@@ -885,7 +874,7 @@ def injection_sql_lab(request):
                     'Lab_2021/A3_Injection/sql_lab.html',
                     {
                         "wrongpass":password,
-                        "sql_error":sql_query
+                        "sql_error": "Invalid credentials"
                     })
 
             if user:
@@ -896,7 +885,7 @@ def injection_sql_lab(request):
                     'Lab_2021/A3_Injection/sql_lab.html',
                     {
                         "wrongpass":password,
-                        "sql_error":sql_query
+                        "sql_error": "Invalid credentials"
                     })
         else:
             return render(request, 'Lab_2021/A3_Injection/sql_lab.html')


### PR DESCRIPTION
## Linked Issue
Closes #419

## Problem
The `sql_lab` and `injection_sql_lab` views construct SQL queries using string concatenation with user input. This introduces a SQL Injection vulnerability because values from `request.POST` are directly inserted into the SQL query.

Example vulnerable pattern:

sql_query = "SELECT * FROM introduction_login WHERE user='" + name + "' AND password='" + password + "'"
login.objects.raw(sql_query)

An attacker could inject malicious SQL payloads to bypass authentication or manipulate database queries.

## Solution
Replaced raw SQL query construction with Django ORM queries using `.filter()` and `.first()`. Django ORM automatically parameterizes queries and prevents SQL injection attacks.

Example fix:

user_obj = login.objects.filter(user=name, password=password).first()

## Changes
- Removed raw SQL query concatenation.
- Replaced `.raw()` queries with Django ORM queries.
- Improved handling of invalid credentials.

## Files Modified
- introduction/views.py