### PR TITLE
Add proper SECURITY.md policy for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in PyGoat, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. Email the maintainers at: security@owasp.org
+2. Include a clear description of the vulnerability
+3. Include steps to reproduce the issue
+4. Include the potential impact of the vulnerability
+5. Include any suggested fixes if available
+
+### What to Expect
+
+- **Acknowledgement** within 48 hours of your report
+- **Status update** within 7 days
+- **Resolution** within 90 days depending on complexity
+
+## Responsible Disclosure Guidelines
+
+- Give maintainers reasonable time to fix the issue before public disclosure
+- Do not exploit the vulnerability beyond what is needed to demonstrate it
+- Do not access or modify data that does not belong to you
+- Act in good faith
+
+## Credits
+
+We appreciate security researchers who help keep PyGoat safe by following responsible disclosure practices.
+


### PR DESCRIPTION
## Summary

The current SECURITY.md file contains only the default GitHub 
template and does not provide actual guidance for reporting 
vulnerabilities.

This PR adds a proper security policy including:
- Supported versions
- Vulnerability reporting instructions
- Responsible disclosure guidelines
- Expected response timeline

Closes #421 — Part of GSoC 2026 application