### PR TITLE
fix(ci): pin flake8>=7.3.0 to resolve pycodestyle compatibility failure

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install 'flake8>=7.3.0'
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Flake8 — syntax errors and undefined names (blocking)


### PR DESCRIPTION
## Summary

   - **Pins `flake8>=7.3.0`** in the CI workflow to fix the `pycodestyle` compatibility
   crash that is currently breaking the Flake8 check on every PR targeting `v3.0.0-pre`

   ## Problem

   The current workflow runs `pip install flake8` without a version pin. This resolves to
    `flake8==7.2.x` which depends on `pycodestyle<2.13`. However, pip now pulls
   `pycodestyle==2.13+`, which removed the `missing_whitespace_after_keyword` function
   that `flake8 7.2` still tries to import. The result:

   ```
   flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "pycodestyle"
   due to cannot import name 'missing_whitespace_after_keyword' from 'pycodestyle'
   ```

   This means **no PR can pass the Flake8 CI check right now** — the linter crashes
   before it even reads any Python code.

   ## Fix

   `flake8>=7.3.0` correctly pins its dependency to `pycodestyle>=2.14.0,<2.15.0`, which
   restores compatibility. This is a one-line change to `.github/workflows/flake8.yml`.

   This fix must land on the base branch (`v3.0.0-pre`) because GitHub Actions reads
   workflow files from the **target branch** for `pull_request` events — so changes to
   workflow files in feature-branch PRs have no effect on CI behaviour.

   ## Test plan

   - [ ] Verify this PR's own Flake8 check passes (it won't, since the workflow file is
   read from the base branch — but a direct push or merge will validate it)
   - [ ] After merge, re-run Flake8 checks on any open PR (e.g. #388) to confirm they
   pass

   Fixes the root cause of Flake8 failures across all open PRs.