### PR TITLE
fix(ci): install flake8 after requirements.txt and remove stale linter pins

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install 'flake8>=7.3.0'
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install --upgrade 'flake8>=7.3.0'
 
       - name: Flake8 — syntax errors and undefined names (blocking)
         run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,13 +14,10 @@ django-allauth==0.52.0
 django-crispy-forms==2.3
 gunicorn==23.0.0
 idna==3.4
-mccabe==0.6.1
 oauthlib==3.2.2
 Pillow==12.1.0
 pre_commit==4.5.1
-pycodestyle==2.7.0
 pycparser==2.21
-pyflakes==2.3.1
 PyJWT==2.4.0
 python3-openid==3.2.0
 pytz==2020.1


### PR DESCRIPTION
 ## Summary

  - Reorders flake8 install to run **after** `requirements.txt` with `--upgrade`, so
  flake8's transitive deps always win
  - Removes stale linter pins (`pycodestyle==2.7.0`, `pyflakes==2.3.1`, `mccabe==0.6.1`)
  from `requirements.txt` — these are not app dependencies

  ## Problem

  PR #429 pinned `flake8>=7.3.0` but installs it **before** `requirements.txt`. The stale
  linter pins in `requirements.txt` then **downgrade** `pycodestyle` from `2.14.0` back to
  `2.7.0`, re-triggering the same `ImportError`:

  ImportError: cannot import name 'missing_whitespace_after_keyword' from 'pycodestyle'

  This means flake8 CI is still broken for any PR that touches `.py` files.

  ## Fix

  1. **Reorder install**: `requirements.txt` first, then `flake8>=7.3.0` with `--upgrade` —
  ensures flake8's deps are never downgraded
  2. **Remove stale pins**: `pycodestyle`, `pyflakes`, and `mccabe` are not imported
  anywhere in the codebase — they were leftover from a `pip freeze` and serve no purpose in
  `requirements.txt`

  ## Test plan

  - [ ] Flake8 CI check passes on this PR after merge
  - [ ] Re-run flake8 on any open PR (e.g. #388) to confirm it works