### PR TITLE
fix: add migration for merging OWASP model removals, update authentication in registration. and add CSRF user table

### DIFF
--- a/introduction/migrations/0023_merge_owasp_model_removals.py
+++ b/introduction/migrations/0023_merge_owasp_model_removals.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("introduction", "0022_remove_owasp2017_lab_models"),
+        ("introduction", "0022_remove_owasp2021_lab_models"),
+    ]
+
+    operations = []

--- a/introduction/models.py
+++ b/introduction/models.py
@@ -1,4 +1,8 @@
 from django.db import models
 
-# Create your models here.
-# OWASP 2017, OWASP 2021, and MITRE integrated lab models removed via migrations.
+
+class CSRF_user_tbl(models.Model):
+	username = models.CharField(max_length=200)
+	password = models.CharField(max_length=200)
+	balance = models.IntegerField(default=0)
+	is_loggedin = models.BooleanField(default=False)

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -2,7 +2,7 @@ import random
 import string
 
 from django.contrib import messages
-from django.contrib.auth import login
+from django.contrib.auth import authenticate, login
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import csrf_exempt
 
@@ -18,7 +18,13 @@ def register(request):
         form = NewUserForm(request.POST)
         if form.is_valid():
             user = form.save()
-            login(request, user)
+            authenticated_user = authenticate(
+                request,
+                username=user.username,
+                password=form.cleaned_data.get("password1"),
+            )
+            if authenticated_user is not None:
+                login(request, authenticated_user)
             messages.success(request, "Registration successful.")
             return redirect("/")
         messages.error(request, "Unsuccessful registration. Invalid information.")


### PR DESCRIPTION
# fix: add migration for merging OWASP model removals, update authentication in registration. and add the CSRF user table

## Changelog

- Added model for `CSRF_user_tbl`
- Fixed issue with authentication backend on registration page by using `authenticate` from` django.contrib.auth`
- Added migration for both OWASP removal (2017 and 2022) 