### PR TITLE
feat(ux): insufficient logging lab intro page

### DIFF
--- a/introduction/templates/Lab_2021/A9_InsufficientLogging/insufficient_logging.html
+++ b/introduction/templates/Lab_2021/A9_InsufficientLogging/insufficient_logging.html
@@ -1,0 +1,56 @@
+{% extends 'introduction/base.html' %}
+{% block content %}
+{% block title %}
+<title>Insufficient Logging & Monitoring</title>
+{% endblock %}
+<div class="content">
+    <h3>Insufficient Logging &amp; Monitoring</h3>
+    <div id="lab-controls" data-lab="insufficient_logging_lab"></div>
+    <div class="box">
+        <h4>Introduction</h4>
+        <p class="bp">
+            Insufficient logging and monitoring, coupled with missing or ineffective integration with incident response, allows attackers to further attack systems, maintain persistence, pivot to more systems to tamper with, extract, or destroy data. Most breach studies demonstrate the time to detect a breach is over 200 days, typically detected by external parties rather than internal processes or monitoring.
+        </p>
+    </div>
+
+    <div class="box">
+        <button class="coll btn btn-info">Lab 1 Details</button>
+        <div class="lab">
+            <p class="bp">
+                This lab helps you to get an idea of how sometimes improper logging can result in information disclosure. The user on accessing the lab is given with a login page which tells us that the logs have been leaked. The user needs to find the leak and try to gain the credentials that have been leaked in the logs.
+                <br><br>
+                The log has been exposed in /debug route. This can be found out with subdomain brute-forcing or just by guess. On seeing the Log try to get the required login details as there is a leak and the logging is improperly handled.
+            </p>
+            <br>
+            <div align="right">
+                <a class="btn btn-info lab-access-btn" data-path="/lab1" href="#">Access Lab 1</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="box">
+        <button class="coll btn btn-info">Lab 2 Details</button>
+        <div class="lab">
+            <p class="bp">
+                It seems this application is logging every action performed in this logging page. But is there a way to inject some fake logs to the application?
+            </p>
+            <br>
+            <div align="right">
+                <a class="btn btn-info lab-access-btn" data-path="/lab2" href="#">Access Lab 2</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="box">
+        <h4>Mitigation</h4>
+        <p class="bp">
+        <ul>
+            <li>Ensure that logs are created in a format that can be easily used by central log management tools.</li>
+            <li>High-value transactions should have an audit trail with integrity controls to prevent manipulation or deletion.</li>
+            <li>Effective monitoring and alerting should be established so that suspicious activities can be detected and responded to in a timely manner.</li>
+            <li>Make sure that there aren't any sensitive information like passwords are being logged.</li>
+        </ul>
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/introduction/templates/introduction/base.html
+++ b/introduction/templates/introduction/base.html
@@ -224,11 +224,11 @@
                 </button>
               </li>
               <li>
-                <button onclick="launchLab('insufficient_logging_lab')" class="sidebar-list-items lab-button" data-lab="insufficient_logging_lab">
+                <a href="/insufficient_logging" class="sidebar-list-items lab-button" data-lab="insufficient_logging_lab">
                   <i class="fas fa-bug"></i>
                   A9: Security Logging and Monitoring Failures
                   <span class="lab-status-indicator not-running" aria-hidden="true"></span>
-                </button>
+                </a>
               </li>
               <li>
                 <button onclick="launchLab('ssrf_lab')" class="sidebar-list-items lab-button" data-lab="ssrf_lab">
@@ -665,12 +665,12 @@
                   <span class="lab-status-indicator not-running" aria-hidden="true"></span>
                 </button>
               </li>
-              <li>
-                <button onclick="launchLab('insufficient_logging_lab')" class="sidebar-list-items lab-button" data-lab="insufficient_logging_lab">
+                <li>
+                <a href="/insufficient_logging" class="sidebar-list-items lab-button" data-lab="insufficient_logging_lab">
                   <i class="fas fa-bug"></i>
                   A10: Insufficient Logging & Monitoring
                   <span class="lab-status-indicator not-running" aria-hidden="true"></span>
-                </button>
+                </a>
               </li>
             </ul>
 

--- a/introduction/urls.py
+++ b/introduction/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("A03", views.supply_chain_failures, name="supply_chain_failures"),
     path("auth_failure", views.auth_failure, name="auth_failure"),
     path("2021/A8", views.software_and_data_integrity_failure, name="A8"),
+    path("insufficient_logging", views.insufficient_logging, name="insufficient_logging"),
     ##------------------- mitre endpoints --------------------------------------------------------------|
     path("mitre/1", mitre.mitre_top1, name="mitre_top1"),
     path("mitre/2", mitre.mitre_top2, name="mitre_top2"),

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,4 +292,8 @@ def software_and_data_integrity_failure(request):
             request, "Lab_2021/A8_software_and_data_integrity_failure/desc.html"
         )
 
-
+def insufficient_logging(request):
+    if request.user.is_authenticated:
+        return render(request, "Lab_2021/A9_InsufficientLogging/insufficient_logging.html")
+    else:
+        return redirect("login")


### PR DESCRIPTION
**Follow-up to:** `feat(ux): lab lifecycle controls & manage labs UI refresh`

---

## Summary

Adds the missing Django intro page for `insufficient_logging_lab`. This lab existed as a dockerized container registered in `labs.json` but had no Django URL, view, or template -- the sidebar link had wrong destination. This PR completes the OWASP 2021 and OWASP 2017 coverage by adding the full intro page with lab controls integration.

---

## Changes

**New template** — `introduction/templates/Lab_2021/A9_InsufficientLogging/insufficient_logging.html`  
Lab intro page with description, lab details for both labs, Access Lab buttons wired to container routes, and `lab-controls` div for Start/Stop dashboard integration.

**New view** — `introduction/views.py`  
Added `insufficient_logging()` view with authentication check.

**New URL** — `introduction/urls.py`  
Added `path("insufficient_logging", views.insufficient_logging, name="insufficient_logging")`

**Sidebar** — `introduction/templates/introduction/base.html`  
Updated sidebar link  to `/insufficient_logging` in both OWASP 2021 and 2017 sections.

---

## Lab Details

| | |
|---|---|
| `data-lab` | `insufficient_logging_lab` |
| Lab 1 `data-path` | `/lab1` |
| Lab 2 `data-path` | `/lab2` |

---

## Testing

- [x] Click A9/A10 in OWASP 2021/2017 sidebar → lands on intro page 