### PR TITLE
fix: comment out psycopg2 - not required for SQLite dev setup (#382)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ idna==3.4
 mccabe==0.6.1
 oauthlib==3.2.2
 Pillow==9.4.0
-psycopg2==2.9.3
+# psycopg2==2.9.3  # Not required for SQLite-based dev setup
+
 pycodestyle==2.7.0
 pycparser==2.21
 pyflakes==2.3.1


### PR DESCRIPTION
## Summary
Fixes #382

## Investigation Findings
Checked all .py files for psycopg2 imports → None found
Checked settings.py for PostgreSQL config → Not configured
Current database → SQLite (development)

## Change Made
- `requirements.txt` — commented out psycopg2==2.9.3 with explanation

## Why
Removes unnecessary dependency for new contributors.
psycopg2 only needed for PostgreSQL/Heroku deployment.