### PR TITLE
fix: persist sidebar state across page navigations using localStorage (#360)

### DIFF
--- a/introduction/templates/introduction/base.html
+++ b/introduction/templates/introduction/base.html
@@ -703,19 +703,53 @@
     ></script>
 
     <script type="text/javascript">
-      $(document).ready(function () {
-        $(".sidebar-header").on("click", function () {
-          $("#sidebar").toggleClass("active");
-          $(".pg").toggleClass("active");
-        });
-      });
+
+      // ── Sidebar persistence using localStorage ──────────────────────
+      // Restores collapsed/expanded state across page navigations
+      function saveSidebarState(isCollapsed) {
+        localStorage.setItem('sidebarCollapsed', isCollapsed);
+      }
+
+      function restoreSidebarState() {
+        var isCollapsed = localStorage.getItem('sidebarCollapsed') === 'true';
+        if (isCollapsed) {
+          $('#sidebar').addClass('active');
+          $('.pg').removeClass('active');
+        } else {
+          $('#sidebar').removeClass('active');
+          $('.pg').addClass('active');
+        }
+      }
 
       $(document).ready(function () {
+        // Restore state on every page load
+        restoreSidebarState();
+
+        // Toggle via sidebar header click
+        $(".sidebar-header").on("click", function () {
+          $('#sidebar').toggleClass('active');
+          $('.pg').toggleClass('active');
+          var isCollapsed = $('#sidebar').hasClass('active');
+          saveSidebarState(isCollapsed);
+        });
+
+        // Toggle via PG button click
         $(".pg").on("click", function () {
-          $("#sidebar").toggleClass("active");
-          $(".pg").toggleClass("active");
+          $('#sidebar').toggleClass('active');
+          $('.pg').toggleClass('active');
+          var isCollapsed = $('#sidebar').hasClass('active');
+          saveSidebarState(isCollapsed);
+        });
+
+        // Toggle via Toggle Sidebar button click
+        $("#sidebarCollapse").on("click", function () {
+          $('#sidebar').toggleClass('active');
+          $('.pg').toggleClass('active');
+          var isCollapsed = $('#sidebar').hasClass('active');
+          saveSidebarState(isCollapsed);
         });
       });
+      // ────────────────────────────────────────────────────────────────
 
       function swapStyleSheet() {
         var elem = document.getElementById('stylesheet-toggle');


### PR DESCRIPTION
## Summary
Fixes #360

## Problem
Sidebar collapsed/expanded state was lost on every page navigation.
Users had to re-collapse the sidebar on every page they visited.

## Fix
Added localStorage to save and restore sidebar state across page loads.

## Changes Made
- `introduction/templates/introduction/base.html`
  - Added `saveSidebarState()` — saves state to localStorage on toggle
  - Added `restoreSidebarState()` — restores state on every page load
  - Fixed all 3 toggle methods to save state:
    - Sidebar header click
    - PG button click
    - Toggle Sidebar button click (was not wired before)

## Testing
- Collapse sidebar → navigate to another page → sidebar stays collapsed
- Expand sidebar → navigate → sidebar stays expanded
- All 3 toggle buttons work correctly