### PR TITLE
fix(docker): upgrade base image from python:3.11.0b1-buster to python:3.11-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0b1-buster
+FROM python:3.11-bookworm
 
 
 # set work directory
@@ -6,7 +6,7 @@ WORKDIR /app
 
 
 # dependencies for psycopg2
-RUN apt-get update && apt-get install --no-install-recommends -y dnsutils=1:9.11.5.P4+dfsg-5.1+deb10u11 libpq-dev=11.16-0+deb10u1 python3-dev=3.7.3-1 && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y dnsutils libpq-dev python3-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 # Set environment variables


### PR DESCRIPTION
## Problem
Debian Buster (10) reached End-of-Life on June 30, 2024. The current Dockerfile uses `python:3.11.0b1-buster` which causes:
- `apt-get update` to fail on all fresh installs — Buster mirrors are frozen/removed
- Pinned package versions (`dnsutils=1:9.11.5.P4+dfsg-5.1+deb10u11`, `libpq-dev=11.16-0+deb10u1`, `python3-dev=3.7.3-1`) are Buster-specific and don't exist in any other distro's repos
- `python:3.11.0b1` is a beta release — not a stable tag

## Fix
- Base image updated to `python:3.11-bookworm` (Debian 12 — current stable, LTS until 2028)
- All pinned Buster-specific version numbers removed
- Package list preserved: `dnsutils`, `libpq-dev`, `python3-dev`

## Testing
- `docker build .` completes with zero apt-get errors
- Container starts and Django/gunicorn is reachable on port 8000
- Hadolint CI passes