### PR TITLE
fix(utility): use errno.ECONNREFUSED for cross-platform port detection; fix typo

### DIFF
--- a/challenge/utility.py
+++ b/challenge/utility.py
@@ -1,10 +1,11 @@
 import socket
+import errno
 
 def get_free_port(START_PORT, END_PORT, HOST="localhost"):
     for port in range(START_PORT, END_PORT):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             result = s.connect_ex((HOST, port))
-            if result == 111:
-                print(f"Port {port} is avilable")
+            if result == errno.ECONNREFUSED:
+                print(f"Port {port} is available")
                 return port
     return None


### PR DESCRIPTION
## Problems
**Cross-platform (Medium):** `result == 111` hardcodes the Linux-specific value for `ECONNREFUSED`. On Windows the equivalent is `10061` — `get_free_port()` silently returns `None` on Windows, meaning challenge containers never start.

**Typo (Low):** Print statement says `"avilable"` instead of `"available"`.

## Fix
- `import errno` added
- `result == 111` replaced with `result == errno.ECONNREFUSED` — Python resolves this to the correct value per platform at runtime
- Typo corrected in print statement

## Testing
- Linux: `errno.ECONNREFUSED == 111` — zero functional change
- Windows: `errno.ECONNREFUSED == 10061` — port detection now works correctly
- Flake8 passes — `errno` is used immediately after import