### PR TITLE
Fix cross-platform port availability check in get_free_port

### DIFF
--- a/challenge/utility.py
+++ b/challenge/utility.py
@@ -4,7 +4,7 @@ def get_free_port(START_PORT, END_PORT, HOST="localhost"):
     for port in range(START_PORT, END_PORT):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             result = s.connect_ex((HOST, port))
-            if result == 111:
-                print(f"Port {port} is avilable")
+            if result != 0:
+                print(f"Port {port} is available")
                 return port
     return None


### PR DESCRIPTION
Description:

This PR fixes a cross-platform issue in the get_free_port utility.

Changes:
Replaced hardcoded error check (result == 111) with a generic condition (result != 0)
This ensures compatibility across different operating systems (Linux, Windows, etc.)
Fixed a minor typo in log message ("avilable" → "available")

Why:

The previous implementation relied on a Linux-specific error code (111), which could lead to incorrect behavior on other systems such as Windows (10061).

Using result != 0 provides a more reliable and portable way to detect available ports.

FIXES #472  