### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+PyGoat is an intentionally vulnerable application for educational purposes.
+It should never be deployed in a production environment.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅ Yes    |
+
+## Reporting a Vulnerability
+
+Although PyGoat is intentionally vulnerable by design, if you discover
+an unintended vulnerability or security issue in the project infrastructure
+(CI/CD, dependencies, Docker setup), please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email the maintainers at:
+📧 **owasp-pygoat@owasp.org**
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We aim to respond within **72 hours** and will credit reporters
+in the changelog unless anonymity is requested.
+
+## Security Resources
+
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [OWASP PyGoat Project](https://owasp.org/www-project-pygoat/)
+- [Responsible Disclosure Policy](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html)


### PR DESCRIPTION
**Description:**
```
## Description
PyGoat did not have a SECURITY.md file, leaving contributors and 
users without guidance on how to report security vulnerabilities 
in the project infrastructure responsibly.

Added a SECURITY.md following GitHub's security policy best practices,
including supported versions, responsible disclosure process, and 
contact information.

Fixes #421

## Type of Change
- [x] Documentation update

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review