### PR TITLE
Feature/added multiple demo users in data exposure lab

### DIFF
--- a/dockerized_labs/sensitive_data_exposure/entrypoint.sh
+++ b/dockerized_labs/sensitive_data_exposure/entrypoint.sh
@@ -7,11 +7,33 @@ python manage.py migrate
 
 # Create a demo user if it doesn't exist
 echo "Setting up demo user..."
-# this is a mess but it works
-echo "from django.contrib.auth.models import User; from dataexposure.models import UserData; demo_user = User.objects.filter(username='demo').exists() or User.objects.create_user('demo', 'demo@example.com', 'demopass'); user = User.objects.get(username='demo'); UserData.objects.filter(user=user).exists() or UserData.objects.create(user=user, credit_card='4111111111111111', ssn='123456789', api_key='demokey123456789')" | python manage.py shell
 
-# TODO: need to add more test users to demo the API
-# maybe add user1, user2, user3 with different data
+python manage.py shell << END
+from django.contrib.auth.models import User
+from dataexposure.models import UserData
+
+user = [
+    {"username1" : "user1", "password" : "pass123"}
+    {"username2" : "user2", "password" : "pass123"}
+    {"username3" : "user3", "password" : "pass123"}
+]
+
+for u in users : 
+    user,created = User.objects.get_or_create(username=u["username"])
+    if created:
+    user.set_password(u["username"])
+    user.save()
+
+    UserData.objects.get_or_create(
+    user=user,
+    credit_card="3249873572365",
+    ssn="42542524252"
+    )
+
+print("Demo users created")
+END
+
+
 
 # Create a superuser too (commented out by default)
 # echo "from django.contrib.auth.models import User; User.objects.filter(username='admin').exists() or User.objects.create_superuser('admin', 'admin@example.com', 'adminpass')" | python manage.py shell


### PR DESCRIPTION
This PR improves the demo user setup by adding support for multiple users instead of a single default user.

Changes:
- Added creation of multiple demo users (user1, user2, user3)
- Ensured safe creation using get_or_create
- Assigned default sensitive data for each user
- Improved code readability and removed outdated TODOs

This enhances testing scenarios and makes the lab more flexible.