### PR TITLE
🐞 Fix missing return in auth_lab_signup view

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,7 +292,7 @@ def auth_lab_signup(request):
                 print('Setting cookie successful')
                 return response
             except:
-                render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
+                return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Username already exists'})
 


### PR DESCRIPTION
## Description
The `auth_lab_signup` view in `introduction/views.py` calls `render()` inside an exception block but does not return the response.

Because of this, Django may return `None` instead of an `HttpResponse`, which can lead to unexpected behavior.

## Fix
Added the missing `return` statement before the `render()` call so the response is properly returned.

## Changes
- Updated `introduction/views.py`
- Added `return` before `render()` in the exception block of `auth_lab_signup`

## Related Issue
Closes #493