### PR TITLE
🐞 Fix missing return in auth_lab_login exception block

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,7 +292,7 @@ def auth_lab_signup(request):
                 print('Setting cookie successful')
                 return response
             except:
-                render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
+                return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Username already exists'})
 

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -320,7 +320,7 @@ def auth_lab_login(request):
                 print('Login successful')
                 return response
             except:
-                render(request,'Lab/AUTH/auth_lab_login.html',{'err_msg':'Cookie cannot be set'})
+                return render(request,'Lab/AUTH/auth_lab_login.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_login.html',{'err_msg':'Check your credentials'})
 


### PR DESCRIPTION
## Description
The `auth_lab_login` view in `introduction/views.py` calls `render()` inside an exception block without returning the response.

This causes Django to return `None` instead of a valid `HttpResponse`.

## Fix
Added the missing `return` statement before the `render()` call.

## Changes
- Updated `introduction/views.py`
- Ensured the rendered response is returned properly

Closes #494