### PR TITLE
🐞 Fix error() view returning None instead of HttpResponse

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -401,7 +401,7 @@ def robots(request):
         return response
 
 def error(request):
-    return 
+    return HttpResponse("Error occurred") 
 
 
 #******************************************************  Command Injection  ***********************************************************************#

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,7 +292,7 @@ def auth_lab_signup(request):
                 print('Setting cookie successful')
                 return response
             except:
-                render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
+                return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Username already exists'})
 

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,7 +292,7 @@ def auth_lab_signup(request):
                 print('Setting cookie successful')
                 return response
             except:
-                return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
+                render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Username already exists'})
 


### PR DESCRIPTION
## Description
The error() view in introduction/views.py contained a bare return statement,
which causes Django to return None instead of a valid HttpResponse.

## Fix
Replaced the bare return with HttpResponse("Error occurred") to ensure the view
returns a valid response.

## Files Changed
- introduction/views.py

Closes #495