### PR TITLE
🐞 Fix missing return for redirect in crypto_failure view

### DIFF
--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,7 +292,7 @@ def auth_lab_signup(request):
                 print('Setting cookie successful')
                 return response
             except:
-                render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
+                return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Username already exists'})
 

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -1013,7 +1013,7 @@ def crypto_failure(request):
     if request.user.is_authenticated:
         return render(request,"Lab_2021/A2_Crypto_failur/crypto_failure.html",{"success":False,"failure":False})
     else:
-        redirect('login')
+        return redirect('login')
 
 def crypto_failure_lab(request):
     if request.user.is_authenticated:

--- a/introduction/views.py
+++ b/introduction/views.py
@@ -292,7 +292,7 @@ def auth_lab_signup(request):
                 print('Setting cookie successful')
                 return response
             except:
-                return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
+                render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Cookie cannot be set'})
         except:
             return render(request,'Lab/AUTH/auth_lab_signup.html',{'err_msg':'Username already exists'})
 


### PR DESCRIPTION
## Description
The crypto_failure view in introduction/views.py calls redirect('login')
without returning the response.

This causes the view to return None instead of performing the redirect.

## Fix
Added the missing return statement before redirect('login').

## Files Changed
- introduction/views.py

Closes #496