### PR TITLE
🐞 Fix migration conflict caused by duplicate 0022 migrations in introduction app

### DIFF
--- a/introduction/migrations/0022_remove_owasp2021_lab_models.py
+++ b/introduction/migrations/0022_remove_owasp2021_lab_models.py
@@ -4,7 +4,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("introduction", "0021_csrf_user_tbl"),
+        ("introduction", "0022_remove_owasp2017_lab_models"),
     ]
 
     operations = [


### PR DESCRIPTION
PR Description

This PR resolves a migration conflict in the `introduction `app caused by two migrations sharing the same number 0022.

Conflicting migrations:

```
0022_remove_owasp2017_lab_models.py
0022_remove_owasp2021_lab_models.py
```

Both migrations originally depended on:

`("introduction", "0021_csrf_user_tbl")`

This caused Django to be unable to determine the correct migration order, resulting in a migration conflict.

Fix

The dependency of 0022_remove_owasp2021_lab_models.py has been updated to depend on:

`("introduction", "0022_remove_owasp2017_lab_models")`

This chains the migrations properly and ensures Django applies them in the correct sequence.

Result
Eliminates migration numbering conflict
Ensures consistent migration order
Prevents Django migration crashes
Related Issue

Closes #505 