### PR TITLE
Fix infinite loop in wait_for_health() when container has no HEALTHCHECK configured

### DIFF
--- a/challenge/views.py
+++ b/challenge/views.py
@@ -180,7 +180,11 @@ def wait_for_health(container, timeout=60):
     while True:
         container.reload()
         
-        health_status = container.attrs.get('State', {}).get('Health', {}).get('Status')
+        health_status = container.attrs.get("State", {}).get("Health", {}).get("Status")
+        
+        # Handle case where no HEALTHCHECK exists
+        if health_status is None:
+            return True
         
         if health_status == 'healthy':
             print("Container is HEALTHY!")


### PR DESCRIPTION
   Close #512 
## Overview
Fixes an issue where the `wait_for_health()` function could loop until timeout when a container has no `HEALTHCHECK` configured.

## Problem
When a container does not define a HEALTHCHECK in its Dockerfile, Docker returns `None` for the health status.  
The existing implementation did not handle this case, causing the loop to continue until the timeout was reached. This results in unnecessary waiting and incorrect behavior.

## Solution
Added explicit handling for the `None` health status.  
If `health_status` is `None`, the function immediately returns `True`, since the container has no healthcheck configured and waiting is unnecessary.

```python
if health_status is None:
    return True: