### PR TITLE
Fix dead code in toggle_theme() by implementing theme cookie toggle

### DIFF
--- a/dockerized_labs/template_injection_lab/app.py
+++ b/dockerized_labs/template_injection_lab/app.py
@@ -1,5 +1,6 @@
 from flask import (
     Flask,
+    make_response,
     render_template,
     request,
     redirect,
@@ -64,8 +65,6 @@ def get_blog_posts():
     return posts
 
 
-from flask import request, make_response
-
 @app.route("/toggle-theme")
 def toggle_theme():
     current_theme = request.cookies.get("theme", "light")
@@ -110,10 +109,7 @@ def view_blog(filename):
         return f"Blog post not found: {str(e)}", 404
 
 
-@app.route("/toggle-theme")
-def toggle_theme():
-    """Toggle between light and dark theme."""
-    return "", 204
+
 
 @app.route("/health")
 def health_check():

--- a/dockerized_labs/template_injection_lab/app.py
+++ b/dockerized_labs/template_injection_lab/app.py
@@ -64,10 +64,19 @@ def get_blog_posts():
     return posts
 
 
-@app.route("/")
-def index():
-    """Display the main lab page with instructions."""
-    return render_template("index.html")
+from flask import request, make_response
+
+@app.route("/toggle-theme")
+def toggle_theme():
+    current_theme = request.cookies.get("theme", "light")
+
+    # Toggle theme
+    new_theme = "dark" if current_theme == "light" else "light"
+
+    response = make_response("", 204)
+    response.set_cookie("theme", new_theme)
+
+    return response
 
 
 @app.route("/lab")

--- a/dockerized_labs/template_injection_lab/app.py
+++ b/dockerized_labs/template_injection_lab/app.py
@@ -64,7 +64,7 @@ def get_blog_posts():
                     posts.append({"filename": filename, "title": title})
     return posts
 
-
+@app.route("/")
 @app.route("/toggle-theme")
 def toggle_theme():
     current_theme = request.cookies.get("theme", "light")

--- a/dockerized_labs/template_injection_lab/app.py
+++ b/dockerized_labs/template_injection_lab/app.py
@@ -65,6 +65,10 @@ def get_blog_posts():
     return posts
 
 @app.route("/")
+def index():
+    """Display the main lab page with instructions."""
+    return render_template("index.html")
+    
 @app.route("/toggle-theme")
 def toggle_theme():
     current_theme = request.cookies.get("theme", "light")


### PR DESCRIPTION
Fixes BUG in `dockerized_labs/template_injection_lab/app.py`.

The toggle_theme() function previously returned a 204 response without performing any action, making the theme toggle feature non-functional.

This update:
- Reads the current theme from cookies
- Toggles between light and dark theme
- Sets the updated theme using response.set_cookie()

This removes the dead code and restores expected theme toggle functionality.